### PR TITLE
article add view count and comment count stats and adjust index section width, make it pretty

### DIFF
--- a/migrations/20180103210155_article_stats/down.sql
+++ b/migrations/20180103210155_article_stats/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE article_stats;

--- a/migrations/20180103210155_article_stats/up.sql
+++ b/migrations/20180103210155_article_stats/up.sql
@@ -1,0 +1,9 @@
+-- Your SQL goes here
+CREATE TABLE article_stats (
+  id uuid primary key default gen_random_uuid(),
+  article_id uuid references article (id) not null,
+  created_time timestamp not null default current_timestamp,
+  ruser_id uuid references ruser (id),
+  user_agent varchar,
+  visitor_ip varchar
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,13 +39,15 @@ pub mod web_wechat;
 pub mod proxy;
 
 pub(crate) use models::{Article, ArticleBrief, DeleteArticle, EditArticle, NewArticle};
+pub(crate) use models::{NewArticleStats};
 pub(crate) use models::{ChangStatus, ChangePassword, ChangePermission, EditUser, LoginUser, RUser, RegisteredUser};
 pub(crate) use models::{DeleteComment, NewComment};
 pub(crate) use models::{InsertSection, PubNotice, Section};
-pub(crate) use schema::{article, comment, ruser, section};
+pub(crate) use schema::{article, comment, ruser, section, article_stats};
 pub(crate) use util::{inner_get_github_nickname_and_address, inner_get_github_primary_email,
                       inner_get_github_token, markdown_render, random_string, send_reset_password_email, sha3_256_encode};
 pub(crate) use util::{get_github_nickname_and_address, get_github_primary_email, get_github_token};
+pub(crate) use util::{get_ruser_from_session, get_real_ip_from_req, get_user_agent_from_req};
 
 pub use api::{AdminSection, AdminUser, User, Visitor};
 pub use proxy::ProxyModule;

--- a/src/models/articles_stats.rs
+++ b/src/models/articles_stats.rs
@@ -1,0 +1,48 @@
+use super::super::{article_stats};
+use super::super::article_stats::dsl::article_stats as all_articles_stats;
+
+use chrono::NaiveDateTime;
+use diesel;
+use diesel::PgConnection;
+use diesel::prelude::*;
+use uuid::Uuid;
+
+#[derive(Queryable, Debug, Clone, Serialize, Deserialize)]
+pub struct QueryArticleStats {
+    pub id: Uuid,
+    pub article_id: Uuid,
+    pub created_time: NaiveDateTime,
+    pub ruser_id: Option<Uuid>,
+    pub user_agent: Option<String>,
+    pub visitor_ip: Option<String>,
+}
+
+#[derive(Insertable, Debug, Clone)]
+#[table_name = "article_stats"]
+pub struct NewArticleStats {
+    pub article_id: Uuid,
+    pub ruser_id: Option<Uuid>,
+    pub user_agent: Option<String>,
+    pub visitor_ip: Option<String>,
+}
+
+impl NewArticleStats {
+    pub fn new(self, conn: &PgConnection) -> Result<usize, String> {
+        let res = diesel::insert_into(all_articles_stats)
+            .values(&self)
+            .execute(conn);
+        match res {
+            Ok(data) => Ok(data),
+            Err(err) => Err(format!("{}", err)),
+        }
+    }
+    pub fn insert(self, conn: &PgConnection) -> Result<usize, String> {
+        let res = diesel::insert_into(all_articles_stats)
+            .values(&self)
+            .execute(conn);
+        match res {
+            Ok(data) => Ok(data),
+            Err(err) => Err(format!("{}", err)),
+        }
+    }
+}

--- a/src/models/articles_stats.rs
+++ b/src/models/articles_stats.rs
@@ -27,15 +27,6 @@ pub struct NewArticleStats {
 }
 
 impl NewArticleStats {
-    pub fn new(self, conn: &PgConnection) -> Result<usize, String> {
-        let res = diesel::insert_into(all_articles_stats)
-            .values(&self)
-            .execute(conn);
-        match res {
-            Ok(data) => Ok(data),
-            Err(err) => Err(format!("{}", err)),
-        }
-    }
     pub fn insert(self, conn: &PgConnection) -> Result<usize, String> {
         let res = diesel::insert_into(all_articles_stats)
             .values(&self)

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,11 +2,13 @@ pub mod articles;
 pub mod comments;
 pub mod sections;
 pub mod rusers;
+pub mod articles_stats;
 
 pub(crate) use self::articles::{Article, ArticleBrief, DeleteArticle, EditArticle, NewArticle};
 pub(crate) use self::comments::{CommentWithNickName, DeleteComment, NewComment};
 pub(crate) use self::rusers::{ChangePassword, ChangePermission, EditUser, LoginUser, RUser, RegisteredUser};
 pub(crate) use self::sections::{InsertSection, PubNotice, Section};
+pub(crate) use self::articles_stats::{NewArticleStats};
 
 use uuid::Uuid;
 

--- a/views/detailArticle.html
+++ b/views/detailArticle.html
@@ -219,6 +219,8 @@
             </p>
             <p>
                 <small>标签：{{ res.tags }}</small>
+                <small>浏览：{{ res.view_count }}</small>
+                <small>评论：{{ res.comment_count }}</small>
             </p>
         </div>
         <div class="detail padding-square">

--- a/views/detailSection.html
+++ b/views/detailSection.html
@@ -83,7 +83,10 @@ Rust博客星球 - Rust语言中文社区
         cursor: pointer;
     }
 
-    .body-content .tags, .body-content .createdTime, .author  {
+    .body-content .tags,
+    .body-content .createdTime,
+    .author,
+    .body-content .show-count  {
         color: #666;
         font-size: 14px;
     }
@@ -166,6 +169,7 @@ Rust博客星球 - Rust语言中文社区
                                 <li class="item padding-small-rectangle {% if not loop.last %} underline {% else %} last {% endif %}"
                                     data-index="{{ loop.index0 }}">
                                     <a href="/article/{{ article.id }}">{{ article.title }}</a>
+                                    <span class="show-count" title="浏览：{{article.view_count}}，评论：{{article.comment_count}}">({{article.view_count}},{{article.comment_count}})</span>
                                     <span class="right">
                                         <span class="tags">{{ article.tags }}</span>
                                         <span class="author">{{ article.author_name }}</span> 

--- a/views/index.html
+++ b/views/index.html
@@ -69,10 +69,11 @@ ul li {
 
 .body-content .category-section {
     margin-top: 15px;
+    margin-right: -15px;
 }
 
 .one-section {
-    width: 28%;
+    width: calc(31% - 15px);
     margin-right: 15px;
     margin-bottom: 15px;
     padding: 10px;
@@ -80,6 +81,12 @@ ul li {
     height: 104px;
     float: left;
     min-width: 276px;
+}
+
+@media screen and (max-width: 960px) {
+    .one-section {
+        width: calc(100% - 50px);
+    }
 }
 
 .body-content .incubation-area .incubation-area-container {


### PR DESCRIPTION
create new table article_stats to stats article's view count.
query view count and comment count when use all about article and blog struct, but just show count in section list page and article detail page for now.
in index file, one section row contain three section when container's width outrange 960px, one section when width lower than 960px.