### PR TITLE
渲染服务端化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atty"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -44,13 +44,13 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -59,7 +59,7 @@ name = "backtrace-sys"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -79,7 +79,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -92,19 +92,19 @@ name = "cargo_metadata"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -114,7 +114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -124,8 +124,8 @@ version = "2.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "atty 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -139,7 +139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy_lints 0.0.177 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -155,16 +155,16 @@ dependencies = [
  "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "comrak"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -172,7 +172,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "twoway 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode_categories 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -238,7 +238,7 @@ name = "diesel"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_derives 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -272,7 +272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -296,7 +296,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -327,7 +327,7 @@ dependencies = [
  "ammonia 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.177 (registry+https://github.com/rust-lang/crates.io-index)",
- "comrak 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "comrak 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_infer_schema 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -337,11 +337,12 @@ dependencies = [
  "r2d2_redis 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sapper 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper 0.1.5 (git+https://github.com/DCjanus/sapper.git)",
+ "sapper_ntd 0.1.0 (git+https://github.com/DCjanus/sapper_ntd.git)",
  "sapper_std 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -352,7 +353,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -388,9 +389,9 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "markup5ever 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -438,7 +439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -516,7 +517,7 @@ name = "log"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -536,9 +537,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "phf 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_codegen 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -609,15 +610,15 @@ dependencies = [
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.28"
+version = "0.9.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -710,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -748,7 +749,7 @@ name = "quote"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -814,12 +815,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -831,7 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -847,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -863,7 +864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "sapper"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/DCjanus/sapper.git#5ff1960a9954be507c308f5771ba85d2c03d7d21"
 dependencies = [
  "conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -878,9 +879,9 @@ name = "sapper_body"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "sapper 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper 0.1.5 (git+https://github.com/DCjanus/sapper.git)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -890,8 +891,23 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "sapper 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper 0.1.5 (git+https://github.com/DCjanus/sapper.git)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sapper_ntd"
+version = "0.1.0"
+source = "git+https://github.com/DCjanus/sapper_ntd.git#3bd1a140f3f040329dfa282aa5940a8516e19ffa"
+dependencies = [
+ "sapper 0.1.5 (git+https://github.com/DCjanus/sapper.git)",
+ "sapper_body 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper_logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper_query 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper_session 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper_tmpl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -899,7 +915,7 @@ name = "sapper_query"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "sapper 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper 0.1.5 (git+https://github.com/DCjanus/sapper.git)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -909,7 +925,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cookie 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sapper 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper 0.1.5 (git+https://github.com/DCjanus/sapper.git)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -918,14 +934,14 @@ name = "sapper_std"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "sapper 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sapper 0.1.5 (git+https://github.com/DCjanus/sapper.git)",
  "sapper_body 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapper_logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapper_query 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapper_session 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sapper_tmpl 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -989,37 +1005,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1029,7 +1035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1060,7 +1066,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_codegen 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1072,7 +1078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "phf_generator 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1109,10 +1115,10 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.13.2"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1155,9 +1161,9 @@ dependencies = [
  "humansize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "slug 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1212,7 +1218,7 @@ name = "toml"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1269,7 +1275,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1346,9 +1352,9 @@ name = "uuid"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1395,21 +1401,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ammonia 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd4c682378117e4186a492b2252b9537990e1617f44aed9788b9a1149de45477"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-"checksum atty 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6609a866dd1a1b2d0ee1362195bf3e4f6438abb2d80120b83b1e1f4fb6476dd0"
-"checksum backtrace 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbe525f66f42d207968308ee86bc2dd60aa5fab535b22e616323a173d097d8e"
+"checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
+"checksum backtrace 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea58cd16fd6c9d120b5bcb01d63883ae4cc7ba2aed35c1841b862a3c7ef6639"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-"checksum bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1b2bf7093258c32e0825b635948de528a5949799dcd61bef39534c8aab95870c"
+"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
 "checksum cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be1057b8462184f634c3a208ee35b0f935cfd94b694b26deadccd98732088d7b"
-"checksum cc 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "38fb45eeb2c9216a6700cf675b418d6c26ee15b55a3700970112da9fedfb8694"
-"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
+"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
 "checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
 "checksum clippy 0.0.177 (registry+https://github.com/rust-lang/crates.io-index)" = "131acb21874af5ec9a2ed5b3945edd9961b260735ba0d6879357a924a77be66b"
 "checksum clippy_lints 0.0.177 (registry+https://github.com/rust-lang/crates.io-index)" = "e5ad86d7ff55bf5461ed84388c445ecba69badb2805a5e4750bd57ee12a0f8a2"
-"checksum comrak 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "17a5772ca33e3ec805360145413ccb60e0256b504919d3c7d38bfb844cd0dc75"
+"checksum comrak 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "053b26c8ce23b4c505a9479beace98f95899e0bf5c5255cf0219e9b0f48cf6ea"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum cookie 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "746858cae4eae40fff37e1998320068df317bc247dc91a67c6cfa053afdc2abb"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
@@ -1462,7 +1468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
-"checksum openssl-sys 0.9.28 (registry+https://github.com/rust-lang/crates.io-index)" = "0bbd90640b148b46305c1691eed6039b5c8509bed16991e3562a01eeb76902a3"
+"checksum openssl-sys 0.9.30 (registry+https://github.com/rust-lang/crates.io-index)" = "73ae718c3562989cd3a0a5c26610feca02f8116822f6f195e6cf4887481e57f5"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pest 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e823a5967bb4cdc6d3e46f47baaf4ecfeae44413a642b74ad44e59e49c7f6"
 "checksum pest 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0fce5d8b5cc33983fc74f78ad552b5522ab41442c4ca91606e4236eb4b5ceefc"
@@ -1475,7 +1481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dfb5e575ef93a1b7b2a381d47ba7c5d4e4f73bff37cee932195de769aad9a54"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum proc-macro2 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cd07deb3c6d1d9ff827999c7f9b04cdfd66b1b17ae508e14fe47b620f2282ae0"
-"checksum proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b16749538926f394755373f0dfec0852d79b3bd512a5906ceaeb72ee64a4eaa0"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
@@ -1488,16 +1494,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02a92e223490cc63d9230c4cdf132a48ce154ab1e063558e3841e219c2ea3f91"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
-"checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
-"checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
+"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
+"checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum sapper 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4c201fc4dd56006f379e016c0cc993420ae142ffa757aaaa2b5d314ee044dbdb"
+"checksum sapper 0.1.5 (git+https://github.com/DCjanus/sapper.git)" = "<none>"
 "checksum sapper_body 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cdbe8185fb46c016d8b4555627a945a75d6254b3658f5ccff0ca47743a0e1f"
 "checksum sapper_logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94378a990d3e40cfac5f630153ff631ddf5b4a1722be6f01153580cc6fb1ea89"
+"checksum sapper_ntd 0.1.0 (git+https://github.com/DCjanus/sapper_ntd.git)" = "<none>"
 "checksum sapper_query 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a96df8873f1e0bc3082b4b49172fe56732dad3dfacd946f4b4ba98ddbaf5486d"
 "checksum sapper_session 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2331c007cdfbbf32dc39fba55b4962927b16f2cd807e61be29431e0edbc3dd90"
 "checksum sapper_std 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "397a881d0a5280cafc8b295f4e221621542a1752197b4f8146f8e6f4db12c38a"
@@ -1508,10 +1515,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "0c855d888276f20d140223bd06515e5bf1647fd6d02593cb5792466d9a8ec2d0"
-"checksum serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "aa113e5fc4b008a626ba2bbd41330b56c9987d667f79f7b243e5a2d03d91ed1c"
-"checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
-"checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
+"checksum serde 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "40916f132d93723c5b744f50de984e4c90a43a391b6af9273fcda5f06e28f001"
+"checksum serde_derive 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "382f3ccc4b0b1ecb609070aa2df922beb8f95b30cdf06872d8bc06d5119dacd1"
+"checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
 "checksum serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce0fd303af908732989354c6f02e05e2e6d597152870f2c6990efb0577137480"
 "checksum sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cc30b1e1e8c40c121ca33b86c23308a090d19974ef001b4bf6e61fd1a0fb095c"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
@@ -1522,7 +1528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c97c05b8ebc34ddd6b967994d5c6e9852fa92f8b82b3858c39451f97346dcce5"
-"checksum syn 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1f9bcba3e27a55cf7a1e46acc1568ccf3d92be8e517b8593ff83cb8183cf5cd6"
+"checksum syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "61b8f1b737f929c6516ba46a3133fd6d5215ad8a62f66760f851f7048aebedfb"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tendril 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9de21546595a0873061940d994bbbc5c35f024ae4fd61ec5c5b159115684f508"
@@ -1541,7 +1547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
+"checksum unicode-normalization 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90d662d111b0dbb08a180f2761026cba648c258023c355954a7c00e00e354636"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ authors = ["Mike Tang <miketang84@outlook.com>"]
  ammonia = "^1.0.1"
  hyper-native-tls = "^0.2.4"
  hyper = "^0.10.13"
+ sapper_ntd = {git = "https://github.com/DCjanus/sapper_ntd.git" }
 
 [dependencies.diesel]
 features = ["postgres", "chrono", "uuid", "r2d2"]
@@ -41,6 +42,7 @@ version = "^0.6.3" # 需要注意的是，此处依赖的UUID版本号应与dies
 optional = true
 version = "^0.0.177"
 
-#[patch.crates-io]
+[patch.crates-io]
+sapper = { git = "https://github.com/DCjanus/sapper.git" } # for some feature
 #sapper_std = { git = 'https://github.com/sappworks/sapper_std.git'}
 #sapper = { git = 'https://github.com/sappworks/sapper.git' }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ extern crate serde_json;
 extern crate serde_urlencoded;
 extern crate tiny_keccak;
 extern crate uuid;
+extern crate sapper_ntd;
 
 pub mod api;
 pub mod schema;

--- a/src/web/article.rs
+++ b/src/web/article.rs
@@ -6,6 +6,7 @@ use super::super::{get_real_ip_from_req, get_ruser_from_session, get_user_agent_
 use sapper::{Request, Response, Result as SapperResult, SapperModule, SapperRouter};
 use sapper_std::{render, PathParams};
 use uuid::Uuid;
+use sapper_ntd::get_query_param_value;
 
 pub struct WebArticle;
 
@@ -49,7 +50,11 @@ impl WebArticle {
                 web.add("author", &author);
 
                 // comments
-                let page = 1;
+                let page = get_query_param_value(req, "page")
+                    .unwrap_or("1")
+                    .parse::<i64>()
+                    .unwrap_or(1);
+
                 let comments = CommentWithNickName::comments_with_article_id_paging(
                     &pg_conn,
                     id,

--- a/src/web/section.rs
+++ b/src/web/section.rs
@@ -24,7 +24,10 @@ impl WebSection {
             Ok(i) => i,
             Err(err) => return res_400!(format!("UUID invalid: {}", err)),
         };
-        let page = 1i64;
+        let page = get_query_param_value(req, "page")
+            .unwrap_or("1")
+            .parse::<i64>()
+            .unwrap_or(1);
         web.add("id", &id);
         web.add("page", &page);
 
@@ -74,7 +77,10 @@ impl WebSection {
             Ok(i) => i,
             Err(err) => return res_400!(format!("UUID invalid: {}", err)),
         };
-        let page = 1i64;
+        let page = get_query_param_value(req, "page")
+            .unwrap_or("1")
+            .parse::<i64>()
+            .unwrap_or(1);
         web.add("id", &id);
         web.add("page", &page);
 
@@ -100,6 +106,7 @@ impl WebSection {
                         web.add("articles", &arts.articles);
                         web.add("total", &arts.total);
                         web.add("max_page", &arts.max_page);
+                        web.add("user_blogs", &"true");
 
                         if let Some(suid) = r.suser {
                             let manager = RUser::query_with_id(&pg_conn, suid).unwrap();

--- a/src/web/section.rs
+++ b/src/web/section.rs
@@ -1,8 +1,9 @@
+use sapper::{Request, Response, Result as SapperResult, SapperModule, SapperRouter};
+use sapper_ntd::params_getter::get_query_param_value;
+use sapper_std::{PathParams, render};
 use super::super::{Article, RUser, Section};
 use super::super::{Postgresql, WebContext};
 use super::super::page_size;
-use sapper::{Request, Response, Result as SapperResult, SapperModule, SapperRouter};
-use sapper_std::{render, PathParams};
 use uuid::Uuid;
 
 pub struct WebSection;
@@ -116,7 +117,10 @@ impl WebSection {
     fn blogs(req: &mut Request) -> SapperResult<Response> {
         let mut web = req.ext().get::<WebContext>().unwrap().clone();
         let pg_conn = req.ext().get::<Postgresql>().unwrap().get().unwrap();
-        let page = 1;
+        let page = get_query_param_value(req, "page")
+            .unwrap_or("1")
+            .parse::<i64>()
+            .unwrap_or(1);
         let res = Article::query_blogs_paging(&pg_conn, 1, page, page_size());
 
         match res {

--- a/static/css/gruvbox-light.css
+++ b/static/css/gruvbox-light.css
@@ -5,15 +5,15 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 */
 
 .hljs {
-  display: block;
-  overflow-x: auto;
-  padding: 0.5em;
-  background: #fbf1c7;
+    display: block;
+    overflow-x: auto;
+    padding: 0.5em;
+    background: #fbf1c7;
 }
 
 .hljs,
 .hljs-subst {
-  color: #3c3836;
+    color: #3c3836;
 }
 
 /* Gruvbox Red */
@@ -22,7 +22,7 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 .hljs-keyword,
 .hljs-link,
 .hljs-selector-tag {
-  color: #9d0006;
+    color: #9d0006;
 }
 
 /* Gruvbox Blue */
@@ -33,7 +33,7 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 .hljs-strong,
 .hljs-title,
 .hljs-variable {
-  color: #076678;
+    color: #076678;
 }
 
 /* Gruvbox Yellow */
@@ -41,7 +41,7 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 .hljs-params,
 .hljs-template-tag,
 .hljs-type {
-  color: #b57614;
+    color: #b57614;
 }
 
 /* Gruvbox Purple */
@@ -49,7 +49,7 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 .hljs-doctag,
 .hljs-literal,
 .hljs-number {
-  color: #8f3f71;
+    color: #8f3f71;
 }
 
 /* Gruvbox Orange */
@@ -58,7 +58,7 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 .hljs-regexp,
 .hljs-selector-id,
 .hljs-template-variable {
-  color: #af3a03;
+    color: #af3a03;
 }
 
 /* Gruvbox Green */
@@ -69,7 +69,7 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 .hljs-selector-class,
 .hljs-string,
 .hljs-symbol {
-  color: #79740e;
+    color: #79740e;
 }
 
 /* Gruvbox Aqua */
@@ -81,39 +81,39 @@ Gruvbox style (light) (c) Pavel Pertsev (original style at https://github.com/mo
 .hljs-meta-keyword,
 .hljs-selector-pseudo,
 .hljs-tag {
-  color: #427b58;
+    color: #427b58;
 }
 
 /* Gruvbox Gray */
 .hljs-comment {
-  color: #928374;
+    color: #928374;
 }
 
 /* Gruvbox Purple */
 .hljs-link_label,
 .hljs-literal,
 .hljs-number {
-  color: #8f3f71;
+    color: #8f3f71;
 }
 
 .hljs-comment,
 .hljs-emphasis {
-  font-style: italic;
+    font-style: italic;
 }
 
 .hljs-section,
 .hljs-strong,
 .hljs-tag {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 .news-label {
-	margin: .75rem 1.2rem 0 0;
-	padding: .3rem .4rem;
-	display: inline-block;
-	background-color: #ededed;
-	font-size: .7rem;
-	color: #333;
-	border-radius: .2rem;
-	box-shadow: 2px 2px 2px #c1c1c1;
+    margin: .75rem 1.2rem 0 0;
+    padding: .3rem .4rem;
+    display: inline-block;
+    background-color: #ededed;
+    font-size: .7rem;
+    color: #333;
+    border-radius: .2rem;
+    box-shadow: 2px 2px 2px #c1c1c1;
 }

--- a/static/css/home.css
+++ b/static/css/home.css
@@ -27,12 +27,12 @@ img.round-avatar {
 .navigation ul {
     display: inline-block;
     border-radius: 5px;
-    list-style-type:none;
-    margin:0;
+    list-style-type: none;
+    margin: 0;
     padding: 5px 0;
     font-size: 20px;
     width: 100%;
-    color:#337ab7;
+    color: #337ab7;
 }
 
 .navigation ul li {
@@ -41,9 +41,9 @@ img.round-avatar {
 
 .navigation ul a {
     display: block;
-    text-align:center;
+    text-align: center;
     padding: 10px 20px;
-    text-decoration:none;
+    text-decoration: none;
 }
 
 .navigation ul a:hover {
@@ -95,11 +95,11 @@ input, textarea {
     background-color: #fff;
     border: 1px solid #ccc;
     border-radius: 4px;
-    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-    -webkit-transition: border-color ease-in-out .15s,-webkit-box-shadow ease-in-out .15s;
-    -o-transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
-    transition: border-color ease-in-out .15s,box-shadow ease-in-out .15s;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075);
+    -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+    -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+    transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
 }
 
 input {

--- a/static/js/global.js
+++ b/static/js/global.js
@@ -1,5 +1,5 @@
 // TAB in <textarea>
-$(document).delegate('textarea', 'keydown', function(e) {
+$(document).delegate('textarea', 'keydown', function (e) {
     var keyCode = e.keyCode || e.which;
 
     if (keyCode == 9) {
@@ -26,7 +26,7 @@ function Page() {
 
 var PAGE = new Page();
 
-function checkLoggedIn(run_if_logged_in){
+function checkLoggedIn(run_if_logged_in) {
     var role = $(".role").data("role");
     if (role !== undefined && role === -1) {
         localStorage.setItem("redirect", location.pathname);
@@ -39,7 +39,7 @@ function checkLoggedIn(run_if_logged_in){
         return;
     }
 
-    $.getJSON("/api/v1/user/view", function(response){
+    $.getJSON("/api/v1/user/view", function (response) {
         if (response.status === false) {
             // need login
             localStorage.setItem("redirect", location.pathname);
@@ -65,7 +65,7 @@ function parseQueryStringToDictionary(queryString) {
     // Step 1: separate out each key/value pair
     var parts = queryString.split('&');
 
-    for(var i = 0; i < parts.length; i++) {
+    for (var i = 0; i < parts.length; i++) {
         var p = parts[i];
         // Step 2: Split Key/Value pair
         var keyValuePair = p.split('=');
@@ -122,7 +122,7 @@ Date = function () {
     var args = [].slice.call(arguments);
     args.unshift(_Date);
     if (this instanceof Date) {
-        return new(_Date.bind.apply(_Date, args))();
+        return new (_Date.bind.apply(_Date, args))();
     }
     return (_Date.bind.apply(_Date, args))();
 }

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -5,7 +5,7 @@ function changeActive($node) {
     $node.addClass("active");
 }
 
-$("#information_btn").click(function() {
+$("#information_btn").click(function () {
     changeActive($(this));
     $(".information").css("display", "block");
     $(".modify").css("display", "none");
@@ -45,8 +45,8 @@ $(".change_password :button").click(function (event) {
             url: "/api/v1/user/change_pwd",
             type: "post",
             dataType: "json",
-            data: JSON.stringify({ "old_password": old_password, "new_password": new_password }),
-            headers: { "Content-Type": "application/json" },
+            data: JSON.stringify({"old_password": old_password, "new_password": new_password}),
+            headers: {"Content-Type": "application/json"},
             success: function (res) {
                 if (res.status) {
                     window.location = "/home"
@@ -70,8 +70,8 @@ $(".modify :button").click(function (event) {
             url: "/api/v1/user/edit",
             type: "post",
             dataType: "json",
-            data: JSON.stringify({ "nickname": nickname, "say": say, "avatar": avatar, "wx_openid": wx_openid }),
-            headers: { "Content-Type": "application/json" },
+            data: JSON.stringify({"nickname": nickname, "say": say, "avatar": avatar, "wx_openid": wx_openid}),
+            headers: {"Content-Type": "application/json"},
             success: function (res) {
                 if (res.status) {
                     window.location = "/home"

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -5,7 +5,7 @@ $().ready(function () {
         if (ev.keyCode === 13) {
             if ($("#login_form").css("display") === 'block') {
                 login()
-            } else if ($("#register_form").css("display") === 'block'){
+            } else if ($("#register_form").css("display") === 'block') {
                 register()
             } else {
                 reset_account()
@@ -68,8 +68,8 @@ function login() {
             url: "/api/v1/user/login",
             type: "post",
             dataType: "json",
-            data: JSON.stringify({ "account": account, "password": password, "remember": remember }),
-            headers: { 'Content-Type': 'application/json' },
+            data: JSON.stringify({"account": account, "password": password, "remember": remember}),
+            headers: {'Content-Type': 'application/json'},
             success: function (res) {
                 if (res.status) {
                     var redirect = localStorage.getItem("redirect");
@@ -103,8 +103,8 @@ function register() {
             url: "/api/v1/user/sign_up",
             type: "post",
             dataType: "json",
-            data: JSON.stringify({ "account": account, "password": password, "nickname": nickname }),
-            headers: { "Content-Type": "application/json" },
+            data: JSON.stringify({"account": account, "password": password, "nickname": nickname}),
+            headers: {"Content-Type": "application/json"},
             success: function (res) {
                 if (res.status) {
                     window.location = "/home"
@@ -126,8 +126,8 @@ function reset_account() {
             url: "/api/v1/user/send_reset_pwd_email",
             type: "post",
             dataType: "json",
-            data: JSON.stringify({ "account": account }),
-            headers: { "Content-Type": "application/json" },
+            data: JSON.stringify({"account": account}),
+            headers: {"Content-Type": "application/json"},
             success: function (res) {
                 if (res.status) {
                     window.location = "/login"

--- a/static/js/reset_pwd.js
+++ b/static/js/reset_pwd.js
@@ -13,13 +13,13 @@ $(".change_password :button").click(function (event) {
             url: "/api/v1/user/reset_pwd",
             type: "post",
             dataType: "json",
-            data: JSON.stringify({ "password": new_password, "cookie": cookie }),
-            headers: { "Content-Type": "application/json" },
+            data: JSON.stringify({"password": new_password, "cookie": cookie}),
+            headers: {"Content-Type": "application/json"},
             success: function (res) {
                 if (res.status) {
                     window.location = "/home"
                 } else {
-                    $("#re_password").after("<span class='text-danger' style='display: block'>"+ res.error +"</span>")
+                    $("#re_password").after("<span class='text-danger' style='display: block'>" + res.error + "</span>")
                 }
             }
         });

--- a/static/js/tag.js
+++ b/static/js/tag.js
@@ -1,58 +1,58 @@
-function Tag(inputId){
-	var obj = new Object();
-	if(inputId==null||inputId==""){
-		alert("初始化失败，请检查参数！");
-		return;
-	}
-	obj.inputId = inputId;
-	//初始化
-	obj = (function(obj){
-		obj.tagValue="";
-		obj.isSearchable = false;
-		return obj;
-	})(obj);
-	
-	//初始化界面
-	obj.initView=function(){
-		var inputObj = $("#"+this.inputId);
-		var inputId = this.inputId;
-		inputObj.css("display","none");
-		var appendStr='';
-		appendStr+='<div class="tagsContaine" id="'+inputId+'_tagcontaine">';
-		appendStr+='<div class="tagList"></div>';
-		appendStr+='</div>';
-		inputObj.after(appendStr);
-		var tagInput = $("#"+inputId+"_tagcontaine .tagInput");
-		if(this.tagValue!=null&&this.tagValue!=""){
-			tagTake.setTags(inputId,this.tagValue,this.isSearchable);
-		}
-	}
-	
-	return obj;
+function Tag(inputId) {
+    var obj = new Object();
+    if (inputId == null || inputId == "") {
+        alert("初始化失败，请检查参数！");
+        return;
+    }
+    obj.inputId = inputId;
+    //初始化
+    obj = (function (obj) {
+        obj.tagValue = "";
+        obj.isSearchable = false;
+        return obj;
+    })(obj);
+
+    //初始化界面
+    obj.initView = function () {
+        var inputObj = $("#" + this.inputId);
+        var inputId = this.inputId;
+        inputObj.css("display", "none");
+        var appendStr = '';
+        appendStr += '<div class="tagsContaine" id="' + inputId + '_tagcontaine">';
+        appendStr += '<div class="tagList"></div>';
+        appendStr += '</div>';
+        inputObj.after(appendStr);
+        var tagInput = $("#" + inputId + "_tagcontaine .tagInput");
+        if (this.tagValue != null && this.tagValue != "") {
+            tagTake.setTags(inputId, this.tagValue, this.isSearchable);
+        }
+    }
+
+    return obj;
 }
 
-var tagTake ={
-	"setTags":function(inputId,inputValue,isSearch){
-		if(inputValue==null||inputValue==""){
-			return;
-		}
-		var tagListContaine = $("#"+inputId+"_tagcontaine .tagList");
-		inputValue = inputValue.replace(/，/g,",");
-		var inputValueArray = inputValue.split(",");
-		for(var i=0;i<inputValueArray.length;i++){
-			var valueItem = $.trim(inputValueArray[i]);
-			if(valueItem!=""){
-				var appendListItem = tagTake.getTagItemModel(valueItem,isSearch);
-				tagListContaine.append(appendListItem);
-			}
-		}
-	},
-	"getTagItemModel":function(valueStr,isSearch){
-		if(isSearch){
-			return '<div class="news-label" ><a href ="#">'+valueStr+'</a></div>';
-		} else {
-			return '<div class="news-label"><span>'+valueStr+'</span></div>';
-		}
-	}
+var tagTake = {
+    "setTags": function (inputId, inputValue, isSearch) {
+        if (inputValue == null || inputValue == "") {
+            return;
+        }
+        var tagListContaine = $("#" + inputId + "_tagcontaine .tagList");
+        inputValue = inputValue.replace(/，/g, ",");
+        var inputValueArray = inputValue.split(",");
+        for (var i = 0; i < inputValueArray.length; i++) {
+            var valueItem = $.trim(inputValueArray[i]);
+            if (valueItem != "") {
+                var appendListItem = tagTake.getTagItemModel(valueItem, isSearch);
+                tagListContaine.append(appendListItem);
+            }
+        }
+    },
+    "getTagItemModel": function (valueStr, isSearch) {
+        if (isSearch) {
+            return '<div class="news-label" ><a href ="#">' + valueStr + '</a></div>';
+        } else {
+            return '<div class="news-label"><span>' + valueStr + '</span></div>';
+        }
+    }
 }
 

--- a/views/adminPubNotice.html
+++ b/views/adminPubNotice.html
@@ -1,97 +1,98 @@
 {% extends "base.html" %}
 
 {% block title %}
-创建新公告
+    创建新公告
 {% endblock title %}
 
 {% block content %}
-<style>
-    .padding-rectangle {
-        padding: 10px 15px;
-    }
-</style>
-
-<div id="admin-section" class="padding-rectangle">
-  <b>当前公告</b>
-
-
-  <br>
-  {% if title and desc %}
-  <table border="0">
-      <tbody>
-      <tr>
-          <td>
-              标题: {{ title }}
-          </td>
-      </tr>
-      <tr>
-          <td>
-              内容: {{ desc }}
-          </td>
-      </tr>
-      </tbody>
-  </table>
-  {% else %}
-    无
-  {% endif %}
-  <br>
-
-
-    <b>创建新公告</b>
-    <br>
-    <br>
-    <form>
-        <table border="0">
-            <tbody>
-            <tr>
-                <td>
-                    <input type="text" size="20" autofocus="autofocus" placeholder="公告标题" id="title">
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <textarea rows="4" cols="50" placeholder="公告内容" id="desc"></textarea>
-                </td>
-            </tr>
-            </tbody>
-        </table>
-        <br>
-        <input type="button" id="submit" data-type="" data-uid="{{ user.id }}" data-api="/api/v1/pub_notice/new" value="创建"/>
-    </form>
-    <br/>
-    <br>
-</div>
-
-<script type="application/javascript">
-    $("#submit").on("click", function () {
-        var title = $("input#title").val();
-        var desc = $("textarea#desc").val();
-        var uid = $(this).data("uid");
-        var type = 0;
-
-        if (title.trim().length === 0 || desc.trim().length === 0) {
-            alert("请填写标题和描述");
-            return
+    <style>
+        .padding-rectangle {
+            padding: 10px 15px;
         }
+    </style>
 
-        $.ajax({
-            type: "POST",
-            url: $("#submit").data("api"),
-            contentType: 'application/json; charset=utf-8',
-            dataType: "json",
-            data: JSON.stringify({
-                title: title,
-                desc: desc
-            }),
-            success: function (response) {
-                if (response.status === true) {
-                    alert("创建成功!")
-                    window.location.reload();
-                } else {
-                    alert("创建失败...???");
-                }
+    <div id="admin-section" class="padding-rectangle">
+        <b>当前公告</b>
+
+
+        <br>
+        {% if title and desc %}
+            <table border="0">
+                <tbody>
+                <tr>
+                    <td>
+                        标题: {{ title }}
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        内容: {{ desc }}
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        {% else %}
+            无
+        {% endif %}
+        <br>
+
+
+        <b>创建新公告</b>
+        <br>
+        <br>
+        <form>
+            <table border="0">
+                <tbody>
+                <tr>
+                    <td>
+                        <input type="text" size="20" autofocus="autofocus" placeholder="公告标题" id="title">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <textarea rows="4" cols="50" placeholder="公告内容" id="desc"></textarea>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <br>
+            <input type="button" id="submit" data-type="" data-uid="{{ user.id }}" data-api="/api/v1/pub_notice/new"
+                   value="创建"/>
+        </form>
+        <br/>
+        <br>
+    </div>
+
+    <script type="application/javascript">
+        $("#submit").on("click", function () {
+            var title = $("input#title").val();
+            var desc = $("textarea#desc").val();
+            var uid = $(this).data("uid");
+            var type = 0;
+
+            if (title.trim().length === 0 || desc.trim().length === 0) {
+                alert("请填写标题和描述");
+                return
             }
-        });
-    })
-</script>
+
+            $.ajax({
+                type: "POST",
+                url: $("#submit").data("api"),
+                contentType: 'application/json; charset=utf-8',
+                dataType: "json",
+                data: JSON.stringify({
+                    title: title,
+                    desc: desc
+                }),
+                success: function (response) {
+                    if (response.status === true) {
+                        alert("创建成功!")
+                        window.location.reload();
+                    } else {
+                        alert("创建失败...???");
+                    }
+                }
+            });
+        })
+    </script>
 {% endblock content %}

--- a/views/adminSection.html
+++ b/views/adminSection.html
@@ -1,74 +1,75 @@
 {% extends "base.html" %}
 
 {% block title %}
-创建新版块
+    创建新版块
 {% endblock title %}
 
 {% block content %}
-<style>
-    .padding-rectangle {
-        padding: 10px 15px;
-    }
-</style>
-
-<div id="admin-section" class="padding-rectangle">
-    <b>创建新的版块</b>
-    <br>
-    <br>
-    <form>
-        <table border="0">
-            <tbody>
-            <tr>
-                <td>
-                    <input type="text" size="20" autofocus="autofocus" placeholder="版块名称" id="title">
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <input type="text" size="20" placeholder="版块描述" id="description">
-                </td>
-            </tr>
-            </tbody>
-        </table>
-        <br>
-        <input type="button" id="submit" data-type="" data-uid="{{ user.id }}" data-api="/api/v1/section/new" value="创建"/>
-    </form>
-    <br/>
-    <br>
-</div>
-
-<script type="application/javascript">
-    $("#submit").on("click", function () {
-        var title = $("input#title").val();
-        var desc = $("input#description").val();
-        var uid = $(this).data("uid");
-        var type = 0;
-
-        if (title.trim().length === 0 || desc.trim().length === 0) {
-            alert("请填写标题和描述");
-            return
+    <style>
+        .padding-rectangle {
+            padding: 10px 15px;
         }
+    </style>
 
-        $.ajax({
-            type: "POST",
-            url: $("#submit").data("api"),
-            contentType: 'application/json; charset=utf-8',
-            dataType: "json",
-            data: JSON.stringify({
-                title: title,
-                description: desc,
-                stype: type,
-                suer: uid
-            }),
-            success: function (response) {
-                if (response.status === true) {
-                    alert("创建成功!")
-                    window.location.reload();
-                } else {
-                    alert("创建失败...???");
-                }
+    <div id="admin-section" class="padding-rectangle">
+        <b>创建新的版块</b>
+        <br>
+        <br>
+        <form>
+            <table border="0">
+                <tbody>
+                <tr>
+                    <td>
+                        <input type="text" size="20" autofocus="autofocus" placeholder="版块名称" id="title">
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <input type="text" size="20" placeholder="版块描述" id="description">
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+            <br>
+            <input type="button" id="submit" data-type="" data-uid="{{ user.id }}" data-api="/api/v1/section/new"
+                   value="创建"/>
+        </form>
+        <br/>
+        <br>
+    </div>
+
+    <script type="application/javascript">
+        $("#submit").on("click", function () {
+            var title = $("input#title").val();
+            var desc = $("input#description").val();
+            var uid = $(this).data("uid");
+            var type = 0;
+
+            if (title.trim().length === 0 || desc.trim().length === 0) {
+                alert("请填写标题和描述");
+                return
             }
-        });
-    })
-</script>
+
+            $.ajax({
+                type: "POST",
+                url: $("#submit").data("api"),
+                contentType: 'application/json; charset=utf-8',
+                dataType: "json",
+                data: JSON.stringify({
+                    title: title,
+                    description: desc,
+                    stype: type,
+                    suer: uid
+                }),
+                success: function (response) {
+                    if (response.status === true) {
+                        alert("创建成功!")
+                        window.location.reload();
+                    } else {
+                        alert("创建失败...???");
+                    }
+                }
+            });
+        })
+    </script>
 {% endblock content %}

--- a/views/base.html
+++ b/views/base.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, user-scalable=0, minimum-scale=1.0, maximum-scale=1.0">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
 
@@ -19,22 +20,28 @@
             margin: auto;
             padding: 0;
         }
+
         p, ul {
             margin: 0;
             padding: 0;
         }
-	    ul li {
+
+        ul li {
             list-style-type: none;
-	    }
+        }
+
         .right {
             float: right;
         }
+
         .left {
             float: left
         }
+
         .hide {
             display: none;
         }
+
         button {
             display: inline-block;
             min-height: 16px;
@@ -43,22 +50,25 @@
             border-radius: 3px;
             background: #eee;
         }
+
         button:hover {
             background: #ccc;
         }
+
         a {
             text-decoration: none;
             color: black;
         }
+
         h1,
         h2,
         h3,
         h4,
-        h5
-        {   
+        h5 {
             margin: 4px 0;
             padding: 10px 0;
         }
+
         /*
         * {
             font-family: -apple-system, "Helvetica Neue", Helvetica, "Nimbus Sans L", Arial, "Liberation Sans", "PingFang SC", "Hiragino Sans GB", "Source Han Sans CN", "Source Han Sans SC", "Microsoft YaHei", "Wenquanyi Micro Hei", "WenQuanYi Zen Hei", "ST Heiti", SimHei, "WenQuanYi Zen Hei Sharp", sans-serif;;
@@ -67,16 +77,16 @@
     </style>
 </head>
 <body>
-    <div id="header">
-        {% include "header.html" %}
-    </div>
-    <div id="content">
-        {% block content %}{% endblock content %}
-    </div>
-    <div id="footer">
-        {% include "footer.html" %}
-    </div>
-    {% block script %}{% endblock script %}
+<div id="header">
+    {% include "header.html" %}
+</div>
+<div id="content">
+    {% block content %}{% endblock content %}
+</div>
+<div id="footer">
+    {% include "footer.html" %}
+</div>
+{% block script %}{% endblock script %}
 </body>
 
 </html>

--- a/views/base.html
+++ b/views/base.html
@@ -88,6 +88,35 @@
 </div>
 {% block script %}{% endblock script %}
 </body>
+<script type="module">
+    const parent_url_key = 'parent_url';
 
+    document
+        .querySelectorAll('a[data-node-type=child]')
+        .forEach(element => {
+                let element_url = new URL(element.href);
+                element_url.searchParams.set(parent_url_key, location.href);
+                element.href = element_url.toString();
+            }
+        );
+
+    let current_parent_url = new URL(window.location.href)
+        .searchParams
+        .get(parent_url_key);
+
+    if (current_parent_url) {
+        document
+            .querySelectorAll('a[data-node-type=parent]')
+            .forEach(element => element.href = current_parent_url);
+
+        document
+            .querySelectorAll('a[data-node-type=brother]')
+            .forEach(element => {
+                let element_url = new URL(element.href);
+                element_url.searchParams.set(parent_url_key, current_parent_url);
+                element.href = element_url.toString();
+            });
+    }
+</script>
 </html>
 

--- a/views/detailArticle.html
+++ b/views/detailArticle.html
@@ -1,546 +1,550 @@
 {% extends "base.html" %}
 
 {% block title %}
-{{ res.title }} - Rust语言中文社区
+    {{ res.title }} - Rust语言中文社区
 {% endblock title %}
 
 {% block content %}
-<!--<link rel="stylesheet" href="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/styles/default.min.css">-->
-<link rel="stylesheet" href="/css/gruvbox-light.css">
-<script src="/js/highlight.pack.js"></script>
-<script src="/js/tag.js"></script>
-<style>
-    
-    .delete {
-        color: red;
-    }
+    <!--<link rel="stylesheet" href="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.12.0/build/styles/default.min.css">-->
+    <link rel="stylesheet" href="/css/gruvbox-light.css">
+    <script src="/js/highlight.pack.js"></script>
+    <script src="/js/tag.js"></script>
+    <style>
 
-    .reply {
-        color: blue;
-    }
+        .delete {
+            color: red;
+        }
 
-    .edit {
-        color: green;
-    }
+        .reply {
+            color: blue;
+        }
 
-    .return {
-        font-size: 14px;
-        color: #228;
-    }
+        .edit {
+            color: green;
+        }
 
-    .detail {
-        padding: 10px;
-    }
+        .return {
+            font-size: 14px;
+            color: #228;
+        }
 
-    .detail .border {
-        border: gray 1px solid;
-        margin-top: 10px;
-    }
+        .detail {
+            padding: 10px;
+        }
 
-    .detail .padding-square {
-        padding: 15px;
-    }
+        .detail .border {
+            border: gray 1px solid;
+            margin-top: 10px;
+        }
 
-    .detail .padding-rectangle {
-        padding: 10px 15px;
-    }
+        .detail .padding-square {
+            padding: 15px;
+        }
 
-    .detail .margin-top {
-        margin-top: 15px;
-    }
+        .detail .padding-rectangle {
+            padding: 10px 15px;
+        }
 
-    .detail .margin-bottom {
-        margin-bottom: 15px;
-    }
+        .detail .margin-top {
+            margin-top: 15px;
+        }
 
-    .detail .underline {
-        border-bottom: gray 1px solid;
-    }
+        .detail .margin-bottom {
+            margin-bottom: 15px;
+        }
 
-    .detail .topline {
-        border-top: gray 1px solid;
-    }
+        .detail .underline {
+            border-bottom: gray 1px solid;
+        }
 
-    .detail .nodot {
-        list-style: none;
-    }
+        .detail .topline {
+            border-top: gray 1px solid;
+        }
 
-    .detail .edit {
-        color: green;
-    }
+        .detail .nodot {
+            list-style: none;
+        }
 
-    .detail .paging {
-        display: inline-block;
-        border: gray 1px solid;
-        margin: 0;
-        width: 22px;
-        height: 22px;
-        text-align: center;
-        vertical-align: middle;
-        cursor: pointer;
-    }
+        .detail .edit {
+            color: green;
+        }
 
-    .detail textarea {
-        width: 70%;
-        min-height: 220px;
-        min-width: 250px;
-        font-size: 15px;
-    }
+        .detail .paging {
+            display: inline-block;
+            border: gray 1px solid;
+            margin: 0;
+            width: 22px;
+            height: 22px;
+            text-align: center;
+            vertical-align: middle;
+            cursor: pointer;
+        }
 
-    .detail hr {
-        border-top: gray dashed 1px;
-        border-bottom: none;
-    }
+        .detail textarea {
+            width: 70%;
+            min-height: 220px;
+            min-width: 250px;
+            font-size: 15px;
+        }
 
-    .detail * {
-        box-sizing: border-box;
-    }
+        .detail hr {
+            border-top: gray dashed 1px;
+            border-bottom: none;
+        }
 
-    .detail blockquote {
-        margin-left: 0;
-        padding: 10px 10px 2px 20px;
-        border-left: black solid 2px;
-        background: ghostwhite;
-        margin-bottom: 2px;
-        width: 100%;
-    }
+        .detail * {
+            box-sizing: border-box;
+        }
 
-    .detail-body {
-        word-wrap: break-word;
-    }
+        .detail blockquote {
+            margin-left: 0;
+            padding: 10px 10px 2px 20px;
+            border-left: black solid 2px;
+            background: ghostwhite;
+            margin-bottom: 2px;
+            width: 100%;
+        }
 
-    .detail-body p, #comments p {
-        line-height: 24px;
-	margin-top: 6px;
-	margin-bottom: 6px;
-    }
+        .detail-body {
+            word-wrap: break-word;
+        }
 
-    .detail-body a, .comment-content a {
-        text-decoration: underline;
-        color: blue;
-    }
+        .detail-body p, #comments p {
+            line-height: 24px;
+            margin-top: 6px;
+            margin-bottom: 6px;
+        }
 
-    .detail-body a:visited, .comment-content a:visited {
-        color: blueviolet;
-    }
+        .detail-body a, .comment-content a {
+            text-decoration: underline;
+            color: blue;
+        }
 
-    .detail-body img {
-        max-width: 100%;
-    }
+        .detail-body a:visited, .comment-content a:visited {
+            color: blueviolet;
+        }
 
-    pre {
-        background: #eee;
-        padding: 0px;
-        border-radius: 6px;
-        font-family: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
-    }
+        .detail-body img {
+            max-width: 100%;
+        }
 
-    pre code {
-        border-radius: 4px;
-    }
+        pre {
+            background: #eee;
+            padding: 0px;
+            border-radius: 6px;
+            font-family: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
+        }
 
-    div code,
-    p code,
-    ul code
-    {
-        border-radius: 4px;
-        background: pink;
-    }
+        pre code {
+            border-radius: 4px;
+        }
 
-    .detail-body h1,
-    .detail-body h2,
-    .detail-body h3,
-    .detail-body h4,
-    .detail-body h5
-    {
-        background: #eee;
-        padding: 10px 20px;
-        border-radius: 1px;
-    }
+        div code,
+        p code,
+        ul code {
+            border-radius: 4px;
+            background: pink;
+        }
 
-    .detail-body ul {
-        margin: 15px 0 15px 30px;
-    }
+        .detail-body h1,
+        .detail-body h2,
+        .detail-body h3,
+        .detail-body h4,
+        .detail-body h5 {
+            background: #eee;
+            padding: 10px 20px;
+            border-radius: 1px;
+        }
 
-    .detail-body ul li {
-        list-style-type: disc;
-    }
+        .detail-body ul {
+            margin: 15px 0 15px 30px;
+        }
 
-    .comment-title {
-        font-size: 14px;
-        background-color: #e8e8e8;
-    }
+        .detail-body ul li {
+            list-style-type: disc;
+        }
 
-    .vice-title {
-        font-size: 14px;
-    }
-    .created-time {
-        color: #555;
-        font-size: 13px;
-    }
-</style>
+        .comment-title {
+            font-size: 14px;
+            background-color: #e8e8e8;
+        }
 
-<div class="meta"
-     {% if user %}
-     data-role="{{ user.role }}"
-     {% else %}
-     data-role="-1"
-     {% endif %}
-     data-id="{{ res.id }}"
-     data-author-id="{{ author.id }}"
-     data-page-size="{{ page_size }}"
-     style="display: none;"></div>
+        .vice-title {
+            font-size: 14px;
+        }
 
-<div class="detail">
+        .created-time {
+            color: #555;
+            font-size: 13px;
+        }
+    </style>
 
-    <div class="border">
-        <div class="underline padding-rectangle">
-                {% if res.stype == 0 %}
-                <a href="/section/{{ res.section_id }}" class="return">&lt; 返回版块</a>
-                {% else %}
-                <a href="/blog/{{ author.id }}" class="return">&lt; 返回博客</a>
-                {% endif %}
-            <div>
-                <h3><span onclick="javascript: window.location.reload();" style="cursor: pointer;" title="刷新">{{ res.title }}</span></h3>
-            </div>
-            <p class="vice-title">
-                {% if res.stype == 0 %}
-                <!--<a href="/user/{{ author.id }}">{{ author.nickname }}</a>-->
-                <a href="/blog/{{ author.id }}">{{ author.nickname }}</a>
-                {% else %}
-                <a href="/blog/{{ author.id }}">{{ author.nickname }}</a>
-                {% endif %}
-                发表于 <span class="article_created_time"></span>
-
-                {% if user %}
-                {% if user.role <= 1 or user.id == res.author_id %}
-                <a class="edit" href="#">编辑</a>
-                {% endif %}
-                {% endif %}
-            </p>
-            <p>
-                <!-- <small>标签：{{ res.tags }}</small> -->
-                {% if res.tags %}
-                    <div id="tags"></div>
-                {% endif %}
-            </p>
-        </div>
-        <div class="detail padding-square">
-            <div class="title">
-                <div class="detail-body">
-                    {{ res.content | safe }}
-                </div>
-            </div>
-        </div>
-
-        <div id="comments" class="padding-rectangle topline">
-            <div class="margin-bottom">
-                <h3>评论区
-                    <button class="right new-comment">发表新回复</button>
-                </h3>
-            </div>
-
-            {% if comments | length == 0 %}
-            <p class="useless">还没有评论</p>
+    <div class="meta"
+            {% if user %}
+         data-role="{{ user.role }}"
             {% else %}
-                {% for comment in comments %}
-                <div class="item border">
-                    <div class="comment-title padding-rectangle">
-                        {% if comment.author_id == author.id %}
-                        作者
-                        {% endif %}
-                        <a class="author-id" href="/blog/{{ comment.author_id }}">
-                            {{ comment.nickname }}
-                        </a> 
-                        <span class="created-time">{{ comment.created_time }}</span>
-                        {% if user %}
-                            {% if user.role <= 1 or user.id == comment.author_id %}
-                            <a class="delete" data-id="{{ comment.id }}" data-author-id="{{ comment.author_id }}" href="#">删除</a>
-                            {% endif %}
-                            <a class="reply" data-id="{{ comment.id }}"
-                               data-author-id="{{ comment.author_id }}" data-nickname="{{ comment.nickname }}" href="#">回复</a>
-                        {% endif %}
-                    </div>
-                    <div class="comment-content padding-rectangle">
-                        {{ comment.content | safe }}
-                    </div>
-                </div>
-                {% endfor %}
+         data-role="-1"
             {% endif %}
+         data-id="{{ res.id }}"
+         data-author-id="{{ author.id }}"
+         data-page-size="{{ page_size }}"
+         style="display: none;"></div>
 
-            <div class="template item border" style="display: none;">
-                <div class="comment-title padding-rectangle">
-                    <a class="author-id"></a> <span class="created-time"></span>
-                    <a class="delete" data-id="" data-author-id="" href="#" style="display: none;">删除</a>
-                    <a class="reply" data-id="" data-author-id="" href="#" style="display: none;">回复</a>
+    <div class="detail">
+
+        <div class="border">
+            <div class="underline padding-rectangle">
+                {% if res.stype == 0 %}
+                    <a href="/section/{{ res.section_id }}" class="return">&lt; 返回版块</a>
+                {% else %}
+                    <a href="/blog/{{ author.id }}" class="return">&lt; 返回博客</a>
+                {% endif %}
+                <div>
+                    <h3><span onclick="javascript: window.location.reload();" style="cursor: pointer;"
+                              title="刷新">{{ res.title }}</span></h3>
                 </div>
-                <div class="comment-content padding-rectangle"></div>
-            </div>
-        </div>
-
-        <div style="width: 100%; height: 25px;" class="padding-square margin-bottom">
-            <div class="paginator right">
-                {% for _ in range(end=max_page) %}
-                    {% if loop.index == page %}
-                    <a data-page="{{ loop.index }}">{{ loop.index }}</a>
+                <p class="vice-title">
+                    {% if res.stype == 0 %}
+                        <!--<a href="/user/{{ author.id }}">{{ author.nickname }}</a>-->
+                        <a href="/blog/{{ author.id }}">{{ author.nickname }}</a>
                     {% else %}
-                    <a class="paging" data-page="{{ loop.index }}">{{ loop.index }}</a>
+                        <a href="/blog/{{ author.id }}">{{ author.nickname }}</a>
                     {% endif %}
-                {% endfor %}
-                共 {{ total }} 评论, 共 {{ max_page }} 页
-            </div>
-        </div>
+                    发表于 <span class="article_created_time"></span>
 
-        <div id="new-comment" class="padding-rectangle topline" style="display: none;">
-            <div>
-                <h3>添加新评论</h3>
-                <p class="hint" style="display: none"></p>
-                <textarea name="content" placeholder="有何高见？"></textarea>
-                <br> <br>
-                <button name="submit" data-api="/api/v1/comment/new">Biu！发送！</button>
+                    {% if user %}
+                        {% if user.role <= 1 or user.id == res.author_id %}
+                            <a class="edit" href="#">编辑</a>
+                        {% endif %}
+                    {% endif %}
+                </p>
+                <p>
+                    <!-- <small>标签：{{ res.tags }}</small> -->
+                    {% if res.tags %}
+                        <div id="tags"></div>
+                    {% endif %}
+                </p>
+            </div>
+            <div class="detail padding-square">
+                <div class="title">
+                    <div class="detail-body">
+                        {{ res.content | safe }}
+                    </div>
+                </div>
+            </div>
+
+            <div id="comments" class="padding-rectangle topline">
+                <div class="margin-bottom">
+                    <h3>评论区
+                        <button class="right new-comment">发表新回复</button>
+                    </h3>
+                </div>
+
+                {% if comments | length == 0 %}
+                    <p class="useless">还没有评论</p>
+                {% else %}
+                    {% for comment in comments %}
+                        <div class="item border">
+                            <div class="comment-title padding-rectangle">
+                                {% if comment.author_id == author.id %}
+                                    作者
+                                {% endif %}
+                                <a class="author-id" href="/blog/{{ comment.author_id }}">
+                                    {{ comment.nickname }}
+                                </a>
+                                <span class="created-time">{{ comment.created_time }}</span>
+                                {% if user %}
+                                    {% if user.role <= 1 or user.id == comment.author_id %}
+                                        <a class="delete" data-id="{{ comment.id }}"
+                                           data-author-id="{{ comment.author_id }}" href="#">删除</a>
+                                    {% endif %}
+                                    <a class="reply" data-id="{{ comment.id }}"
+                                       data-author-id="{{ comment.author_id }}" data-nickname="{{ comment.nickname }}"
+                                       href="#">回复</a>
+                                {% endif %}
+                            </div>
+                            <div class="comment-content padding-rectangle">
+                                {{ comment.content | safe }}
+                            </div>
+                        </div>
+                    {% endfor %}
+                {% endif %}
+
+                <div class="template item border" style="display: none;">
+                    <div class="comment-title padding-rectangle">
+                        <a class="author-id"></a> <span class="created-time"></span>
+                        <a class="delete" data-id="" data-author-id="" href="#" style="display: none;">删除</a>
+                        <a class="reply" data-id="" data-author-id="" href="#" style="display: none;">回复</a>
+                    </div>
+                    <div class="comment-content padding-rectangle"></div>
+                </div>
+            </div>
+
+            <div style="width: 100%; height: 25px;" class="padding-square margin-bottom">
+                <div class="paginator right">
+                    {% for _ in range(end=max_page) %}
+                        {% if loop.index == page %}
+                            <a data-page="{{ loop.index }}">{{ loop.index }}</a>
+                        {% else %}
+                            <a class="paging" data-page="{{ loop.index }}">{{ loop.index }}</a>
+                        {% endif %}
+                    {% endfor %}
+                    共 {{ total }} 评论, 共 {{ max_page }} 页
+                </div>
+            </div>
+
+            <div id="new-comment" class="padding-rectangle topline" style="display: none;">
+                <div>
+                    <h3>添加新评论</h3>
+                    <p class="hint" style="display: none"></p>
+                    <textarea name="content" placeholder="有何高见？"></textarea>
+                    <br> <br>
+                    <button name="submit" data-api="/api/v1/comment/new">Biu！发送！</button>
+                </div>
             </div>
         </div>
     </div>
-</div>
 
-<script type="application/javascript">
-    "use strict";
-    function hightlight($doms) {
-        $doms.each(function(i, block) {
-            hljs.highlightBlock(block);
-        });
-    }
-    hightlight($("pre code"));
+    <script type="application/javascript">
+        "use strict";
 
-    var tag = new Tag("tags");
-    tag.tagValue = "{{ res.tags }}";
-    tag.initView();
+        function hightlight($doms) {
+            $doms.each(function (i, block) {
+                hljs.highlightBlock(block);
+            });
+        }
 
-    // format article date
-    var datetime_str = "{{ res.created_time }}";
-    $('.article_created_time').text(new Date(datetime_str).LocalFormat());
-    var mbody = $('#comments');
-    mbody.find('.comment-title').each(function (i) {
-        var that = $(this);
-        that.find('.created-time').text(
-            new Date(that.find('.created-time').text()).LocalFormat()
-        );
-    });
+        hightlight($("pre code"));
 
-    // load new page
-    function loadPage(id, page) {
-        var limit = Number($(".meta").data("page-size"));
-        var offset = limit * (page - 1);
+        var tag = new Tag("tags");
+        tag.tagValue = "{{ res.tags }}";
+        tag.initView();
 
-        if (PAGE.page === page) return;
-
-        $.getJSON("/api/v1/comment/query?id=" + id + "&offset=" + offset + "&limit=" + limit, function (response) {
-            $(".item").not(".template").remove();
-
-            for(var i=0, l=response.comments.length; i < l; i++) {
-                var comment = response.comments[i];
-                updateItem(i, comment, i === l-1);
-            }
-            hightlight($(".comment-content code"));
-            addListeners();
+        // format article date
+        var datetime_str = "{{ res.created_time }}";
+        $('.article_created_time').text(new Date(datetime_str).LocalFormat());
+        var mbody = $('#comments');
+        mbody.find('.comment-title').each(function (i) {
+            var that = $(this);
+            that.find('.created-time').text(
+                new Date(that.find('.created-time').text()).LocalFormat()
+            );
         });
 
-        activePageBtn(page);
-    }
+        // load new page
+        function loadPage(id, page) {
+            var limit = Number($(".meta").data("page-size"));
+            var offset = limit * (page - 1);
 
-    // update one article DOM
-    function updateItem(index, content, isLast) {
-        // clone template
-        var $newNode = $(".template").clone();
-        $newNode.removeClass("template");
-        $newNode.show();
+            if (PAGE.page === page) return;
 
-        // put data in
-        $newNode.data("index", index);
-        $newNode.find("a.author-id")
-            .attr("href", "/blog/"+content.author_id)
-            .text(content.nickname);
-        $newNode.find(".created-time")
-            .text((new Date(content.created_time)).LocalFormat());
-        $newNode.find(".comment-content")
-            .html(content.content);
-        $newNode.find(".delete")
-            .data("id", content.id)
-            .data("author-id", content.author_id)
-            .show();
+            $.getJSON("/api/v1/comment/query?id=" + id + "&offset=" + offset + "&limit=" + limit, function (response) {
+                $(".item").not(".template").remove();
 
-        if ($(".meta").data("role") !== -1) {
-            $newNode.find(".reply")
+                for (var i = 0, l = response.comments.length; i < l; i++) {
+                    var comment = response.comments[i];
+                    updateItem(i, comment, i === l - 1);
+                }
+                hightlight($(".comment-content code"));
+                addListeners();
+            });
+
+            activePageBtn(page);
+        }
+
+        // update one article DOM
+        function updateItem(index, content, isLast) {
+            // clone template
+            var $newNode = $(".template").clone();
+            $newNode.removeClass("template");
+            $newNode.show();
+
+            // put data in
+            $newNode.data("index", index);
+            $newNode.find("a.author-id")
+                .attr("href", "/blog/" + content.author_id)
+                .text(content.nickname);
+            $newNode.find(".created-time")
+                .text((new Date(content.created_time)).LocalFormat());
+            $newNode.find(".comment-content")
+                .html(content.content);
+            $newNode.find(".delete")
                 .data("id", content.id)
                 .data("author-id", content.author_id)
-                .data("nickname", content.nickname)
                 .show();
-        }
 
-        if (isLast) {
-            $newNode.removeClass("underline");
-        }
-        $newNode.appendTo($("#comments"));
-    }
-
-    // change activated page button
-    function activePageBtn(page) {
-        // transform pagination
-        $(".paginator a[data-page='"+PAGE.page+"']").addClass("paging");
-        $(".paging[data-page='"+page+"']").removeClass("paging");
-        PAGE.update(page);
-    }
-
-    function getArticleID() {
-        return window.location.pathname.split('/')[2];
-    }
-
-    function deleteComment(commentID, authorID, callback) {
-        $.ajax({
-            type: "POST",
-            url: "/api/v1/comment/delete",
-            contentType: 'application/json; charset=utf-8',
-            dataType: "json",
-            data: JSON.stringify({
-                comment_id: commentID,
-                author_id: authorID
-            }),
-            success: function (response) {
-                if (callback !== undefined) {
-                    callback(response);
-                }
+            if ($(".meta").data("role") !== -1) {
+                $newNode.find(".reply")
+                    .data("id", content.id)
+                    .data("author-id", content.author_id)
+                    .data("nickname", content.nickname)
+                    .show();
             }
-        })
-    }
 
-    function listenDeleteClick() {
-        $("a.delete").on("click", function(e) {
-            e.preventDefault();
-            var $this = $(this);
+            if (isLast) {
+                $newNode.removeClass("underline");
+            }
+            $newNode.appendTo($("#comments"));
+        }
 
-            var commentID = $this.data("id");
-            var authorID = $this.data("author-id");
+        // change activated page button
+        function activePageBtn(page) {
+            // transform pagination
+            $(".paginator a[data-page='" + PAGE.page + "']").addClass("paging");
+            $(".paging[data-page='" + page + "']").removeClass("paging");
+            PAGE.update(page);
+        }
 
-            if (!confirm("确认删除？")) return;
+        function getArticleID() {
+            return window.location.pathname.split('/')[2];
+        }
 
-            deleteComment(commentID, authorID, function(response) {
-                if (response.status === true) {
-                    alert("删除成功");
-                    $this.closest("div.item").remove();
-                } else {
-                    alert("删除失败");
+        function deleteComment(commentID, authorID, callback) {
+            $.ajax({
+                type: "POST",
+                url: "/api/v1/comment/delete",
+                contentType: 'application/json; charset=utf-8',
+                dataType: "json",
+                data: JSON.stringify({
+                    comment_id: commentID,
+                    author_id: authorID
+                }),
+                success: function (response) {
+                    if (callback !== undefined) {
+                        callback(response);
+                    }
                 }
-            });
-        });
-    }
-
-    function listenReplyClick() {
-        $("a.reply").on("click", function(e) {
-            e.preventDefault();
-            var $this = $(this);
-
-            var nickname = $this.data("nickname");
-            // comment author id
-            var replyUserId = $this.data("author-id");
-
-            /* @current aaa @xx bbb @xx cc */
-            var originText = "@" + nickname + " "
-                + $this.closest(".item").find(".comment-content").text().trim();
-            var replies = originText.split('@')
-            var history = replies.map(function (rpl, index) {
-                return ("@" + rpl).trim().split("\n").map(function(line) {
-                    return "> ".repeat(index) + line;
-                }).join("\n");
             })
-            history.shift();
-            var markdown = "\n\n" + history.join("\n")
-
-            $(".hint").text("正在回复 @" + nickname).show();
-            $("div#new-comment")
-                .show()
-                .find("textarea")
-                .data("markdown", markdown)
-                .data("reply-user-id", replyUserId)
-                .focus();
-        });
-    }
-
-    function addListeners() {
-        listenDeleteClick();
-        listenReplyClick();
-    }
-
-    function submit() {
-        var $textarea = $("textarea[name='content']");
-        var content = $textarea.val();
-
-        if (content.trim().length === 0) {
-            alert("请输入评论内容！");
-            return;
         }
 
-        var markdown = $textarea.data("markdown");
-        if (markdown !== undefined && markdown.indexOf("@") > -1) {
-            content += markdown;
-            // clear reply hidden text
-            $textarea.data("markdown", "");
-        }
-        var replyData = {
-            content: content,
-            article_id: getArticleID()
-        };
-        var replyUserId = $textarea.data("reply-user-id");
-        if (replyUserId && replyUserId.length) {
-            replyData['reply_user_id'] = replyUserId;
+        function listenDeleteClick() {
+            $("a.delete").on("click", function (e) {
+                e.preventDefault();
+                var $this = $(this);
+
+                var commentID = $this.data("id");
+                var authorID = $this.data("author-id");
+
+                if (!confirm("确认删除？")) return;
+
+                deleteComment(commentID, authorID, function (response) {
+                    if (response.status === true) {
+                        alert("删除成功");
+                        $this.closest("div.item").remove();
+                    } else {
+                        alert("删除失败");
+                    }
+                });
+            });
         }
 
-        $.ajax({
-            type: "POST",
-            url: $("button[name='submit']").data("api"),
-            contentType: 'application/json; charset=utf-8',
-            dataType: "json",
-            data: JSON.stringify(replyData),
-            success: function (response) {
-                if (response.status === true) {
-                    window.location.reload();
-                } else {
-                    alert("发射失败...???");
+        function listenReplyClick() {
+            $("a.reply").on("click", function (e) {
+                e.preventDefault();
+                var $this = $(this);
+
+                var nickname = $this.data("nickname");
+                // comment author id
+                var replyUserId = $this.data("author-id");
+
+                /* @current aaa @xx bbb @xx cc */
+                var originText = "@" + nickname + " "
+                    + $this.closest(".item").find(".comment-content").text().trim();
+                var replies = originText.split('@')
+                var history = replies.map(function (rpl, index) {
+                    return ("@" + rpl).trim().split("\n").map(function (line) {
+                        return "> ".repeat(index) + line;
+                    }).join("\n");
+                })
+                history.shift();
+                var markdown = "\n\n" + history.join("\n")
+
+                $(".hint").text("正在回复 @" + nickname).show();
+                $("div#new-comment")
+                    .show()
+                    .find("textarea")
+                    .data("markdown", markdown)
+                    .data("reply-user-id", replyUserId)
+                    .focus();
+            });
+        }
+
+        function addListeners() {
+            listenDeleteClick();
+            listenReplyClick();
+        }
+
+        function submit() {
+            var $textarea = $("textarea[name='content']");
+            var content = $textarea.val();
+
+            if (content.trim().length === 0) {
+                alert("请输入评论内容！");
+                return;
+            }
+
+            var markdown = $textarea.data("markdown");
+            if (markdown !== undefined && markdown.indexOf("@") > -1) {
+                content += markdown;
+                // clear reply hidden text
+                $textarea.data("markdown", "");
+            }
+            var replyData = {
+                content: content,
+                article_id: getArticleID()
+            };
+            var replyUserId = $textarea.data("reply-user-id");
+            if (replyUserId && replyUserId.length) {
+                replyData['reply_user_id'] = replyUserId;
+            }
+
+            $.ajax({
+                type: "POST",
+                url: $("button[name='submit']").data("api"),
+                contentType: 'application/json; charset=utf-8',
+                dataType: "json",
+                data: JSON.stringify(replyData),
+                success: function (response) {
+                    if (response.status === true) {
+                        window.location.reload();
+                    } else {
+                        alert("发射失败...???");
+                    }
                 }
-            }
-        })
-    }
+            })
+        }
 
 
-    $(function() {
-        // page button click event
-        $(".paginator a").on("click", function() {
-            loadPage(getArticleID(), $(this).data("page"));
+        $(function () {
+            // page button click event
+            $(".paginator a").on("click", function () {
+                loadPage(getArticleID(), $(this).data("page"));
+            });
+
+            // new comment
+            $("button.new-comment").on("click", function () {
+                function run_if_logged_in() {
+                    // show DOM
+                    $("div#new-comment").show();
+                    $("textarea[name='content']").focus();
+                    // hide reply hint
+                    $(".hint").text("").hide();
+                }
+
+                checkLoggedIn(run_if_logged_in);
+            });
+
+            // new article button event
+            $("button[name='submit']").on("click", submit);
+
+            // edit article
+            $(".edit").on("click", function () {
+                var uri = '/user/article/edit?id=' + $('.meta').data("id");
+                window.location.href = uri;
+            });
+
+            addListeners();
+            ctrlEnterThen($('textarea'), submit);
         });
-
-        // new comment
-        $("button.new-comment").on("click", function () {
-            function run_if_logged_in() {
-                // show DOM
-                $("div#new-comment").show();
-                $("textarea[name='content']").focus();
-                // hide reply hint
-                $(".hint").text("").hide();
-            }
-
-            checkLoggedIn(run_if_logged_in);
-        });
-
-        // new article button event
-        $("button[name='submit']").on("click", submit);
-
-        // edit article
-        $(".edit").on("click", function () {
-            var uri = '/user/article/edit?id=' + $('.meta').data("id");
-            window.location.href = uri;
-        });
-
-        addListeners();
-        ctrlEnterThen($('textarea'), submit);
-    });
-</script>
+    </script>
 {% endblock content %}

--- a/views/detailArticle.html
+++ b/views/detailArticle.html
@@ -130,7 +130,7 @@
 
         pre {
             background: #eee;
-            padding: 0px;
+            padding: 0;
             border-radius: 6px;
             font-family: "Source Code Pro", Menlo, Monaco, Consolas, "DejaVu Sans Mono", Inconsolata, monospace;
         }
@@ -195,9 +195,9 @@
         <div class="border">
             <div class="underline padding-rectangle">
                 {% if res.stype == 0 %}
-                    <a href="/section/{{ res.section_id }}" class="return">&lt; 返回版块</a>
+                    <a data-node-type="parent" href="/section/{{ res.section_id }}" class="return">&lt; 返回版块</a>
                 {% else %}
-                    <a href="/blog/{{ author.id }}" class="return">&lt; 返回博客</a>
+                    <a data-node-type="parent" href="/blog/{{ author.id }}" class="return">&lt; 返回博客</a>
                 {% endif %}
                 <div>
                     <h3><span onclick="window.location.reload();" style="cursor: pointer;"
@@ -284,7 +284,7 @@
                 <div class="paginator right">
                     {% for _ in range(end=max_page) %}
                         {% if loop.index < 5 or loop.index > max_page - 3 %}
-                            <a href="/article/{{ res.id }}?page={{ loop.index }}"
+                            <a data-node-type="brother" href="/article/{{ res.id }}?page={{ loop.index }}"
                                     {% if loop.index==page %} class="paging" {% endif %}>
                                 {{ loop.index }}
                             </a>
@@ -333,41 +333,6 @@
                 new Date(that.find('.created-time').text()).LocalFormat()
             );
         });
-
-        // update one article DOM
-        function updateItem(index, content, isLast) {
-            // clone template
-            var $newNode = $(".template").clone();
-            $newNode.removeClass("template");
-            $newNode.show();
-
-            // put data in
-            $newNode.data("index", index);
-            $newNode.find("a.author-id")
-                .attr("href", "/blog/" + content.author_id)
-                .text(content.nickname);
-            $newNode.find(".created-time")
-                .text((new Date(content.created_time)).LocalFormat());
-            $newNode.find(".comment-content")
-                .html(content.content);
-            $newNode.find(".delete")
-                .data("id", content.id)
-                .data("author-id", content.author_id)
-                .show();
-
-            if ($(".meta").data("role") !== -1) {
-                $newNode.find(".reply")
-                    .data("id", content.id)
-                    .data("author-id", content.author_id)
-                    .data("nickname", content.nickname)
-                    .show();
-            }
-
-            if (isLast) {
-                $newNode.removeClass("underline");
-            }
-            $newNode.appendTo($("#comments"));
-        }
 
         function getArticleID() {
             return window.location.pathname.split('/')[2];

--- a/views/detailArticle.html
+++ b/views/detailArticle.html
@@ -284,15 +284,10 @@
                 <div class="paginator right">
                     {% for _ in range(end=max_page) %}
                         {% if loop.index < 5 or loop.index > max_page - 3 %}
-                            {% if loop.index==page %}
-                                <a class="paging" href="/article/{{ res.id }}?page={{ loop.index }}">
-                                    {{ loop.index }}
-                                </a>
-                            {% else %}
-                                <a href="/article/{{ res.id }}?page={{ loop.index }}">
-                                    {{ loop.index }}
-                                </a>
-                            {% endif %}
+                            <a href="/article/{{ res.id }}?page={{ loop.index }}"
+                                    {% if loop.index==page %} class="paging" {% endif %}>
+                                {{ loop.index }}
+                            </a>
                         {% elif loop.index == 5 %}
                             <span>.....</span>
                         {% endif %}

--- a/views/detailArticle.html
+++ b/views/detailArticle.html
@@ -421,9 +421,10 @@
             var commentID = $this.data("id");
             var authorID = $this.data("author-id");
 
+            if (!confirm("确认删除？")) return;
+
             deleteComment(commentID, authorID, function(response) {
                 if (response.status === true) {
-                    if (!confirm("确认删除？")) return;
                     alert("删除成功");
                     $this.closest("div.item").remove();
                 } else {

--- a/views/detailArticle.html
+++ b/views/detailArticle.html
@@ -200,7 +200,7 @@
                     <a href="/blog/{{ author.id }}" class="return">&lt; 返回博客</a>
                 {% endif %}
                 <div>
-                    <h3><span onclick="javascript: window.location.reload();" style="cursor: pointer;"
+                    <h3><span onclick="window.location.reload();" style="cursor: pointer;"
                               title="刷新">{{ res.title }}</span></h3>
                 </div>
                 <p class="vice-title">
@@ -283,10 +283,18 @@
             <div style="width: 100%; height: 25px;" class="padding-square margin-bottom">
                 <div class="paginator right">
                     {% for _ in range(end=max_page) %}
-                        {% if loop.index == page %}
-                            <a data-page="{{ loop.index }}">{{ loop.index }}</a>
-                        {% else %}
-                            <a class="paging" data-page="{{ loop.index }}">{{ loop.index }}</a>
+                        {% if loop.index < 5 or loop.index > max_page - 3 %}
+                            {% if loop.index==page %}
+                                <a class="paging" href="/article/{{ res.id }}?page={{ loop.index }}">
+                                    {{ loop.index }}
+                                </a>
+                            {% else %}
+                                <a href="/article/{{ res.id }}?page={{ loop.index }}">
+                                    {{ loop.index }}
+                                </a>
+                            {% endif %}
+                        {% elif loop.index == 5 %}
+                            <span>.....</span>
                         {% endif %}
                     {% endfor %}
                     共 {{ total }} 评论, 共 {{ max_page }} 页
@@ -331,27 +339,6 @@
             );
         });
 
-        // load new page
-        function loadPage(id, page) {
-            var limit = Number($(".meta").data("page-size"));
-            var offset = limit * (page - 1);
-
-            if (PAGE.page === page) return;
-
-            $.getJSON("/api/v1/comment/query?id=" + id + "&offset=" + offset + "&limit=" + limit, function (response) {
-                $(".item").not(".template").remove();
-
-                for (var i = 0, l = response.comments.length; i < l; i++) {
-                    var comment = response.comments[i];
-                    updateItem(i, comment, i === l - 1);
-                }
-                hightlight($(".comment-content code"));
-                addListeners();
-            });
-
-            activePageBtn(page);
-        }
-
         // update one article DOM
         function updateItem(index, content, isLast) {
             // clone template
@@ -385,14 +372,6 @@
                 $newNode.removeClass("underline");
             }
             $newNode.appendTo($("#comments"));
-        }
-
-        // change activated page button
-        function activePageBtn(page) {
-            // transform pagination
-            $(".paginator a[data-page='" + PAGE.page + "']").addClass("paging");
-            $(".paging[data-page='" + page + "']").removeClass("paging");
-            PAGE.update(page);
         }
 
         function getArticleID() {
@@ -450,14 +429,14 @@
                 /* @current aaa @xx bbb @xx cc */
                 var originText = "@" + nickname + " "
                     + $this.closest(".item").find(".comment-content").text().trim();
-                var replies = originText.split('@')
+                var replies = originText.split('@');
                 var history = replies.map(function (rpl, index) {
                     return ("@" + rpl).trim().split("\n").map(function (line) {
                         return "> ".repeat(index) + line;
                     }).join("\n");
-                })
+                });
                 history.shift();
-                var markdown = "\n\n" + history.join("\n")
+                var markdown = "\n\n" + history.join("\n");
 
                 $(".hint").text("正在回复 @" + nickname).show();
                 $("div#new-comment")
@@ -516,11 +495,6 @@
 
 
         $(function () {
-            // page button click event
-            $(".paginator a").on("click", function () {
-                loadPage(getArticleID(), $(this).data("page"));
-            });
-
             // new comment
             $("button.new-comment").on("click", function () {
                 function run_if_logged_in() {

--- a/views/detailSection.html
+++ b/views/detailSection.html
@@ -171,7 +171,8 @@
                                 {% for article in articles %}
                                     <li class="item padding-small-rectangle {% if not loop.last %} underline {% else %} last {% endif %}"
                                         data-index="{{ loop.index0 }}">
-                                        <a href="/article/{{ article.id }}">{{ article.title }}</a>
+                                        <a data-node-type="child"
+                                           href="/article/{{ article.id }}">{{ article.title }}</a>
                                         <span class="show-count"
                                               title="浏览：{{ article.view_count }}，评论：{{ article.comment_count }}">({{ article.view_count }},{{ article.comment_count }})</span>
                                         <span class="right">
@@ -226,10 +227,22 @@
                 <div class="paginator right">
                     {% for _ in range(end=max_page) %}
                         {% if loop.index < 5 or loop.index > max_page - 3 %}
-                            <a href="/blogs?page={{ loop.index }}"
-                                    {% if loop.index==page %} class="paging" {% endif %}>
-                                {{ loop.index }}
-                            </a>
+                            {% if blog_planet %}
+                                <a data-node-type="brother" href="/blogs?page={{ loop.index }}"
+                                        {% if loop.index==page %} class="paging" {% endif %}>
+                                    {{ loop.index }}
+                                </a>
+                            {% elif user_blogs %}
+                                <a data-node-type="brother" href="/blog/{{ user.id }}?page={{ loop.index }}"
+                                        {% if loop.index==page %} class="paging" {% endif %}>
+                                    {{ loop.index }}
+                                </a>
+                            {% else %}
+                                <a data-node-type="brother" href="/section/{{ res.id }}?page={{ loop.index }}"
+                                        {% if loop.index==page %} class="paging" {% endif %}>
+                                    {{ loop.index }}
+                                </a>
+                            {% endif %}
                         {% elif loop.index == 5 %}
                             <span>.....</span>
                         {% endif %}

--- a/views/detailSection.html
+++ b/views/detailSection.html
@@ -1,201 +1,207 @@
 {% extends "base.html" %}
 
 {% block title %}
-{% if blog_planet %}
-Rust博客星球 - Rust语言中文社区
-{% else %}
-{{ res.title }} - Rust语言中文社区
-{% endif %}
+    {% if blog_planet %}
+        Rust博客星球 - Rust语言中文社区
+    {% else %}
+        {{ res.title }} - Rust语言中文社区
+    {% endif %}
 {% endblock title %}
 
 {% block content %}
-<style>
-    .body-content {
-        padding: 10px;
-    }
+    <style>
+        .body-content {
+            padding: 10px;
+        }
 
-    .body-content .blogs {
-        border: gray 1px solid;
-        padding: 4px;
-        min-height: 24px;
-        line-height: 24px;
-        text-align: center;
-        margin-top: 5px;
-    }
+        .body-content .blogs {
+            border: gray 1px solid;
+            padding: 4px;
+            min-height: 24px;
+            line-height: 24px;
+            text-align: center;
+            margin-top: 5px;
+        }
 
-    .body-content .border {
-        border: gray 1px solid;
-        margin-top: 10px;
-    }
+        .body-content .border {
+            border: gray 1px solid;
+            margin-top: 10px;
+        }
 
-    .body-content .padding-square {
-        padding: 15px;
-    }
+        .body-content .padding-square {
+            padding: 15px;
+        }
 
-    .body-content .padding-rectangle {
-        padding: 10px 15px;
-    }
+        .body-content .padding-rectangle {
+            padding: 10px 15px;
+        }
 
-    .body-content .padding-small-rectangle {
-        padding: 5px 10px;
-    }
+        .body-content .padding-small-rectangle {
+            padding: 5px 10px;
+        }
 
-    .body-content .margin-top {
-        margin-top: 15px;
-    }
+        .body-content .margin-top {
+            margin-top: 15px;
+        }
 
-    .body-content .margin-bottom {
-        margin-bottom: 15px;
-    }
+        .body-content .margin-bottom {
+            margin-bottom: 15px;
+        }
 
-    .body-content .topline {
-        border-top: gray 1px solid;
-    }
+        .body-content .topline {
+            border-top: gray 1px solid;
+        }
 
-    .body-content .underline {
-        border-bottom: gray 1px solid;
-    }
+        .body-content .underline {
+            border-bottom: gray 1px solid;
+        }
 
-    .body-content .nodot {
-        list-style: none;
-    }
+        .body-content .nodot {
+            list-style: none;
+        }
 
-    .body-content .paging {
-        display: inline-block;
-        border: gray 1px solid;
-        margin: 0;
-        width: 22px;
-        height: 22px;
-        text-align: center;
-        vertical-align: middle;
-    }
+        .body-content .paging {
+            display: inline-block;
+            border: gray 1px solid;
+            margin: 0;
+            width: 22px;
+            height: 22px;
+            text-align: center;
+            vertical-align: middle;
+        }
 
-    .body-content * {
-        box-sizing: border-box;
-    }
+        .body-content * {
+            box-sizing: border-box;
+        }
 
-    .body-content a {
-        text-decoration-line: none;
-    }
+        .body-content a {
+            text-decoration-line: none;
+        }
 
-    .body-content a:hover {
-        color: cornflowerblue;
-        cursor: pointer;
-    }
+        .body-content a:hover {
+            color: cornflowerblue;
+            cursor: pointer;
+        }
 
-    .body-content .tags,
-    .body-content .createdTime,
-    .author,
-    .body-content .show-count  {
-        color: #666;
-        font-size: 14px;
-    }
+        .body-content .tags,
+        .body-content .createdTime,
+        .author,
+        .body-content .show-count {
+            color: #666;
+            font-size: 14px;
+        }
 
-    .body-content .input {
-        min-width: 280px;
-        height: 30px;
-        font-size: 18px;
-        width: 60%;
-    }
+        .body-content .input {
+            min-width: 280px;
+            height: 30px;
+            font-size: 18px;
+            width: 60%;
+        }
 
-    .body-content textarea {
-        width: 100%;
-        min-width: 280px;
-        min-height: 400px;
-        font-size: 15px;
-    }
+        .body-content textarea {
+            width: 100%;
+            min-width: 280px;
+            min-height: 400px;
+            font-size: 15px;
+        }
 
-    span.delete {
-        color: red;
-        cursor: pointer;
-    }
-    span.edit {
-        color: green;
-        cursor: pointer;
-    }
+        span.delete {
+            color: red;
+            cursor: pointer;
+        }
 
-</style>
+        span.edit {
+            color: green;
+            cursor: pointer;
+        }
 
-<div class="meta hide"
-     {% if user %}
-     data-role="{{ user.role }}"
-     data-user-id="{{ user.id }}"
-     {% endif %}
-></div>
+    </style>
 
-<div class="body-content">
-    {% if blog_planet %}
-    <div class="blogs">
-        <p>Rust博客星球，我们的家园</p>
-    </div>
-    {% endif %}
-
-    <div class="border">
-        {% if not blog_planet %}
-        <div class="underline padding-rectangle">
-            <div>
-                <h3><span id="section_id" data-id={{ res.id }}
-                    onclick="javascript: window.location.reload()"
-                    title="刷新"
-                    style="cursor: pointer;"
-                >{{ res.title }}</span></h3>
-                {% if manager %}
-                <!--
-                <small>{% if res.stype == 0 %}管理员{% else %}作者{% endif %}：<a href="/user/{{ manager.id }}">{{ manager.nickname }}</a></small>
-                -->
-                {% endif %}
-                {% if res.stype == 0 %}
-                <button class="right new-article">发表新帖子</button>
-                {% elif user and res.suser == user.id %}
-                <button class="right new-article">发表新文章</button>
-                {% endif %}
-            </div>
-            <p>
-                <small>{{ res.description }}</small>
-            </p>
-            {% if res.stype == 1 %}
-            <label>Github：</label><a style="display:inline;" class="github" href={{ manager.github }}>{{ manager.github }}</a>
+    <div class="meta hide"
+            {% if user %}
+         data-role="{{ user.role }}"
+         data-user-id="{{ user.id }}"
             {% endif %}
-        </div>
+    ></div>
+
+    <div class="body-content">
+        {% if blog_planet %}
+            <div class="blogs">
+                <p>Rust博客星球，我们的家园</p>
+            </div>
         {% endif %}
-        <div class="detail padding-square">
-            <div class="title border">
-                <div class="detail-body">
-                    {% if articles | length == 0 %}
-                        <p class="padding-rectangle">这里还没有内容哦..</p>
-                    {% else %}
-                        <ul class="nodot items">
-                            {% for article in articles %}
-                                <li class="item padding-small-rectangle {% if not loop.last %} underline {% else %} last {% endif %}"
-                                    data-index="{{ loop.index0 }}">
-                                    <a href="/article/{{ article.id }}">{{ article.title }}</a>
-                                    <span class="show-count" title="浏览：{{article.view_count}}，评论：{{article.comment_count}}">({{article.view_count}},{{article.comment_count}})</span>
-                                    <span class="right">
+
+        <div class="border">
+            {% if not blog_planet %}
+                <div class="underline padding-rectangle">
+                    <div>
+                        <h3><span id="section_id" data-id={{ res.id }}
+                                onclick="javascript: window.location.reload()"
+                            title="刷新"
+                            style="cursor: pointer;"
+                            >{{ res.title }}</span></h3>
+                        {% if manager %}
+                            <!--
+                <small>{% if res.stype == 0 %}管理员{% else %}
+                                作者{% endif %}：<a href="/user/{{ manager.id }}">{{ manager.nickname }}</a></small>
+                -->
+                        {% endif %}
+                        {% if res.stype == 0 %}
+                            <button class="right new-article">发表新帖子</button>
+                        {% elif user and res.suser == user.id %}
+                            <button class="right new-article">发表新文章</button>
+                        {% endif %}
+                    </div>
+                    <p>
+                        <small>{{ res.description }}</small>
+                    </p>
+                    {% if res.stype == 1 %}
+                        <label>Github：</label>
+                        <a style="display:inline;" class="github" href={{ manager.github }}>{{ manager.github }}</a>
+                    {% endif %}
+                </div>
+            {% endif %}
+            <div class="detail padding-square">
+                <div class="title border">
+                    <div class="detail-body">
+                        {% if articles | length == 0 %}
+                            <p class="padding-rectangle">这里还没有内容哦..</p>
+                        {% else %}
+                            <ul class="nodot items">
+                                {% for article in articles %}
+                                    <li class="item padding-small-rectangle {% if not loop.last %} underline {% else %} last {% endif %}"
+                                        data-index="{{ loop.index0 }}">
+                                        <a href="/article/{{ article.id }}">{{ article.title }}</a>
+                                        <span class="show-count"
+                                              title="浏览：{{ article.view_count }}，评论：{{ article.comment_count }}">({{ article.view_count }},{{ article.comment_count }})</span>
+                                        <span class="right">
                                         <span class="tags">{{ article.tags }}</span>
                                         <span class="author">{{ article.author_name }}</span> 
-                                        <span class="createdTimePlaceholder" style="display: none">{{ article.created_time }}</span>
+                                        <span class="createdTimePlaceholder"
+                                              style="display: none">{{ article.created_time }}</span>
                                         <span class="createdTime"></span>
-                                        {% if user %}
-                                            {% if user.role <= 1 or user.id == article.author_id %}
-                                            <span class="delete" data-id="{{ article.id }}"
-                                                  data-author-id="{{ article.author_id }}"
-                                                  data-user-id="{{ user.id }}">删除</span>
+                                            {% if user %}
+                                                {% if user.role <= 1 or user.id == article.author_id %}
+                                                    <span class="delete" data-id="{{ article.id }}"
+                                                          data-author-id="{{ article.author_id }}"
+                                                          data-user-id="{{ user.id }}">删除</span>
+                                                {% endif %}
+                                                {% if user.id == article.author_id %}
+                                                    <span class="edit" data-id="{{ article.id }}"
+                                                          data-author-id="{{ article.author_id }}"
+                                                          data-user-id="{{ user.id }}">编辑</span>
+                                                {% endif %}
                                             {% endif %}
-                                            {% if user.id == article.author_id %}
-                                            <span class="edit" data-id="{{ article.id }}"
-                                                  data-author-id="{{ article.author_id }}"
-                                                  data-user-id="{{ user.id }}">编辑</span>
-                                            {% endif %}
-                                        {% endif %}
                                     </span>
-                                    <div style="clear:both;"></div>
-                                </li>
-                            {% endfor %}
+                                        <div style="clear:both;"></div>
+                                    </li>
+                                {% endfor %}
 
-                            <li class="item padding-small-rectangle underline template" data-index="" style="display: none">
-                                <a href=""></a>
-                                <span class="show-count" title=""></span>
-                                <span class="right">
+                                <li class="item padding-small-rectangle underline template" data-index=""
+                                    style="display: none">
+                                    <a href=""></a>
+                                    <span class="show-count" title=""></span>
+                                    <span class="right">
                                     <span class="tags"></span>
                                     <span class="author"></span>
                                     <span class="createdTimePlaceholder" style="display: none"></span>
@@ -209,188 +215,189 @@ Rust博客星球 - Rust语言中文社区
                                           data-author-id=""
                                           data-user-id="">编辑</span>
                                 </span>
-                                <div style="clear:both;"></div>
-                            </li>
-                        </ul>
-                    {% endif %}
+                                    <div style="clear:both;"></div>
+                                </li>
+                            </ul>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <div style="width: 100%; height: 25px;" class="padding-square margin-bottom">
+                <div class="paginator right">
+                    {% for _ in range(end=max_page) %}
+                        {% if loop.index == page %}
+                            <a data-page="{{ loop.index }}">{{ loop.index }}</a>
+                        {% else %}
+                            <a class="paging" data-page="{{ loop.index }}">{{ loop.index }}</a>
+                        {% endif %}
+                    {% endfor %}
+                    共 {{ total }} 篇, 共 {{ max_page }} 页
                 </div>
             </div>
         </div>
-        <div style="width: 100%; height: 25px;" class="padding-square margin-bottom">
-            <div class="paginator right">
-                {% for _ in range(end=max_page) %}
-                    {% if loop.index == page %}
-                    <a data-page="{{ loop.index }}">{{ loop.index }}</a>
-                    {% else %}
-                    <a class="paging" data-page="{{ loop.index }}">{{ loop.index }}</a>
-                    {% endif %}
-                {% endfor %}
-                共 {{ total }} 篇, 共 {{ max_page }} 页
-            </div>
-        </div>
     </div>
-</div>
 
-<script type="application/javascript">
-    "use strict";
-    // load new page
-    function loadPage(sectionID, page) {
-        if (PAGE.page === page) return;
-        var is_blog = {% if blog_planet  %} true {% else %} false {% endif %};
-        var url = is_blog? 
-            "/api/v1/blogs/paging?" + "&page=" + page : 
-            "/api/v1/article/paging?id=" + sectionID + "&page=" + page;
+    <script type="application/javascript">
+        "use strict";
 
-        $.getJSON(url, function (response) {
-            $("li.item").not("li.template").remove();
+        // load new page
+        function loadPage(sectionID, page) {
+            if (PAGE.page === page) return;
+            var is_blog = {% if blog_planet  %} true {% else %} false {% endif %};
+            var url = is_blog ?
+                "/api/v1/blogs/paging?" + "&page=" + page :
+                "/api/v1/article/paging?id=" + sectionID + "&page=" + page;
 
-            for(var i=0, l=response.articles.length; i < l; i++) {
-                var article = response.articles[i];
-                updateItem(i, article, i === l-1);
-            }
-            activePageBtn(page);
-            replaceTime();
-            addListeners();
-        });
-    }
+            $.getJSON(url, function (response) {
+                $("li.item").not("li.template").remove();
 
-    // delete article
-    function deleteArticle(articleID, authorID, success) {
-        $.ajax({
-            type: "POST",
-            url: "/api/v1/article/delete",
-            contentType: 'application/json; charset=utf-8',
-            dataType: "json",
-            data: JSON.stringify({
-                article_id: articleID,
-                user_id: authorID
-            }),
-            success: function (response) {
-                if (response.status === true) {
-                    success();
-                } else {
-                    alert("删除失败");
+                for (var i = 0, l = response.articles.length; i < l; i++) {
+                    var article = response.articles[i];
+                    updateItem(i, article, i === l - 1);
                 }
-            }
-        });
-    }
-
-    // update one article DOM
-    function updateItem(index, content, isLast) {
-        // clone template
-        var $newNode = $("li.template").clone();
-        $newNode.removeClass("template");
-        $newNode.show();
-
-        // put data in
-        $newNode.data("index", index);
-        $newNode.find("a")
-            .attr("href", "/article/"+content.id)
-            .text(content.title);
-        $newNode.find(".show-count")
-            .attr("title", "浏览："+ (content.view_count || 0) +"，评论："+ (content.comment_count || 0))
-            .text("("+(content.view_count || 0)+","+(content.comment_count || 0)+")");
-        $newNode.find(".tags")
-            .text(content.tags);
-        $newNode.find(".author")
-            .text(content.author_name);
-        $newNode.find(".createdTimePlaceholder")
-            .text(content.created_time);
-
-        var $meta = $(".meta");
-        var userID = $meta.data("user-id");
-        var role = $meta.data("role");
-        if (userID !== undefined) {
-            if (Number(role) <= 1 || userID === content.author_id) {
-                $newNode.find(".delete")
-                    .data("user-id", userID)
-                    .data("id", content.id)
-                    .data("author-id", content.author_id)
-                    .removeClass("hide");
-            }
-
-            if (userID === content.author_id) {
-                $newNode.find(".edit")
-                    .data("user-id", userID)
-                    .data("id", content.id)
-                    .data("author-id", content.author_id)
-                    .removeClass("hide");
-            }
+                activePageBtn(page);
+                replaceTime();
+                addListeners();
+            });
         }
 
-        if (isLast) {
-            $newNode.removeClass("underline");
-        }
-        $newNode.appendTo($("ul.items"));
-    }
-
-    // change activated page button
-    function activePageBtn(page) {
-        // transform pagination
-        $(".paginator a[data-page='"+PAGE.page+"']").addClass("paging");
-        $(".paging[data-page='"+page+"']").removeClass("paging");
-        PAGE.update(page);
-    }
-
-    function getSectionID() {
-      return $("#section_id").data("id");
-    }
-
-    function getStype() {
-        if (window.location.pathname.split("/")[1] === "blog") {
-            return 1
-        } else {
-            return 0
-        }
-    }
-
-    function replaceTime() {
-        var mbody = $('.detail-body');
-        mbody.find('li').each(function (i) {
-            var that = $(this);
-            that.find('.createdTime').text(
-                new Date(that.find('.createdTimePlaceholder').text()).LocalFormat()
-            );
-        });
-    }
-
-    function addListeners() {
         // delete article
-        $("li span.delete").on("click", function() {
-            var $this = $(this);
-            if (!confirm("确认删除？")) return;
-            deleteArticle(
-                $this.data("id"),
-                $this.data("author-id"),
-                function () {
-                    alert("删除成功！");
-                    $this.closest('li').remove();
+        function deleteArticle(articleID, authorID, success) {
+            $.ajax({
+                type: "POST",
+                url: "/api/v1/article/delete",
+                contentType: 'application/json; charset=utf-8',
+                dataType: "json",
+                data: JSON.stringify({
+                    article_id: articleID,
+                    user_id: authorID
+                }),
+                success: function (response) {
+                    if (response.status === true) {
+                        success();
+                    } else {
+                        alert("删除失败");
+                    }
                 }
-            );
-        });
+            });
+        }
 
-        // edit article
-        $("li span.edit").on("click", function () {
-            var uri = '/user/article/edit?id=' + $(this).data("id");
-            window.location.href = uri;
-        });
-    }
+        // update one article DOM
+        function updateItem(index, content, isLast) {
+            // clone template
+            var $newNode = $("li.template").clone();
+            $newNode.removeClass("template");
+            $newNode.show();
 
-    $(function () {
-            replaceTime();
-            addListeners();
+            // put data in
+            $newNode.data("index", index);
+            $newNode.find("a")
+                .attr("href", "/article/" + content.id)
+                .text(content.title);
+            $newNode.find(".show-count")
+                .attr("title", "浏览：" + (content.view_count || 0) + "，评论：" + (content.comment_count || 0))
+                .text("(" + (content.view_count || 0) + "," + (content.comment_count || 0) + ")");
+            $newNode.find(".tags")
+                .text(content.tags);
+            $newNode.find(".author")
+                .text(content.author_name);
+            $newNode.find(".createdTimePlaceholder")
+                .text(content.created_time);
 
-            // page button click event
-            $(".paginator a").on("click", function() {
-                loadPage(getSectionID(), $(this).data("page"));
+            var $meta = $(".meta");
+            var userID = $meta.data("user-id");
+            var role = $meta.data("role");
+            if (userID !== undefined) {
+                if (Number(role) <= 1 || userID === content.author_id) {
+                    $newNode.find(".delete")
+                        .data("user-id", userID)
+                        .data("id", content.id)
+                        .data("author-id", content.author_id)
+                        .removeClass("hide");
+                }
+
+                if (userID === content.author_id) {
+                    $newNode.find(".edit")
+                        .data("user-id", userID)
+                        .data("id", content.id)
+                        .data("author-id", content.author_id)
+                        .removeClass("hide");
+                }
+            }
+
+            if (isLast) {
+                $newNode.removeClass("underline");
+            }
+            $newNode.appendTo($("ul.items"));
+        }
+
+        // change activated page button
+        function activePageBtn(page) {
+            // transform pagination
+            $(".paginator a[data-page='" + PAGE.page + "']").addClass("paging");
+            $(".paging[data-page='" + page + "']").removeClass("paging");
+            PAGE.update(page);
+        }
+
+        function getSectionID() {
+            return $("#section_id").data("id");
+        }
+
+        function getStype() {
+            if (window.location.pathname.split("/")[1] === "blog") {
+                return 1
+            } else {
+                return 0
+            }
+        }
+
+        function replaceTime() {
+            var mbody = $('.detail-body');
+            mbody.find('li').each(function (i) {
+                var that = $(this);
+                that.find('.createdTime').text(
+                    new Date(that.find('.createdTimePlaceholder').text()).LocalFormat()
+                );
+            });
+        }
+
+        function addListeners() {
+            // delete article
+            $("li span.delete").on("click", function () {
+                var $this = $(this);
+                if (!confirm("确认删除？")) return;
+                deleteArticle(
+                    $this.data("id"),
+                    $this.data("author-id"),
+                    function () {
+                        alert("删除成功！");
+                        $this.closest('li').remove();
+                    }
+                );
             });
 
-            // new article
-            $("button.new-article").on("click", function () {
-                var uri = '/user/article/edit?sectionID=' + getSectionID() + '&stype=' + getStype();
+            // edit article
+            $("li span.edit").on("click", function () {
+                var uri = '/user/article/edit?id=' + $(this).data("id");
                 window.location.href = uri;
             });
         }
-    );
-</script>
+
+        $(function () {
+                replaceTime();
+                addListeners();
+
+                // page button click event
+                $(".paginator a").on("click", function () {
+                    loadPage(getSectionID(), $(this).data("page"));
+                });
+
+                // new article
+                $("button.new-article").on("click", function () {
+                    var uri = '/user/article/edit?sectionID=' + getSectionID() + '&stype=' + getStype();
+                    window.location.href = uri;
+                });
+            }
+        );
+    </script>
 {% endblock content %}

--- a/views/detailSection.html
+++ b/views/detailSection.html
@@ -136,10 +136,10 @@
                 <div class="underline padding-rectangle">
                     <div>
                         <h3><span id="section_id" data-id={{ res.id }}
-                                onclick="javascript: window.location.reload()"
-                            title="刷新"
-                            style="cursor: pointer;"
-                            >{{ res.title }}</span></h3>
+                                onclick="javascript:window.location.reload()"
+                                  title="刷新"
+                                  style="cursor: pointer;">
+                            {{ res.title }}</span></h3>
                         {% if manager %}
                             <!--
                 <small>{% if res.stype == 0 %}管理员{% else %}
@@ -225,10 +225,13 @@
             <div style="width: 100%; height: 25px;" class="padding-square margin-bottom">
                 <div class="paginator right">
                     {% for _ in range(end=max_page) %}
-                        {% if loop.index == page %}
-                            <a data-page="{{ loop.index }}">{{ loop.index }}</a>
-                        {% else %}
-                            <a class="paging" data-page="{{ loop.index }}">{{ loop.index }}</a>
+                        {% if loop.index < 5 or loop.index > max_page - 3 %}
+                            <a href="/blogs?page={{ loop.index }}"
+                                    {% if loop.index==page %} class="paging" {% endif %}>
+                                {{ loop.index }}
+                            </a>
+                        {% elif loop.index == 5 %}
+                            <span>.....</span>
                         {% endif %}
                     {% endfor %}
                     共 {{ total }} 篇, 共 {{ max_page }} 页
@@ -239,27 +242,6 @@
 
     <script type="application/javascript">
         "use strict";
-
-        // load new page
-        function loadPage(sectionID, page) {
-            if (PAGE.page === page) return;
-            var is_blog = {% if blog_planet  %} true {% else %} false {% endif %};
-            var url = is_blog ?
-                "/api/v1/blogs/paging?" + "&page=" + page :
-                "/api/v1/article/paging?id=" + sectionID + "&page=" + page;
-
-            $.getJSON(url, function (response) {
-                $("li.item").not("li.template").remove();
-
-                for (var i = 0, l = response.articles.length; i < l; i++) {
-                    var article = response.articles[i];
-                    updateItem(i, article, i === l - 1);
-                }
-                activePageBtn(page);
-                replaceTime();
-                addListeners();
-            });
-        }
 
         // delete article
         function deleteArticle(articleID, authorID, success) {
@@ -280,63 +262,6 @@
                     }
                 }
             });
-        }
-
-        // update one article DOM
-        function updateItem(index, content, isLast) {
-            // clone template
-            var $newNode = $("li.template").clone();
-            $newNode.removeClass("template");
-            $newNode.show();
-
-            // put data in
-            $newNode.data("index", index);
-            $newNode.find("a")
-                .attr("href", "/article/" + content.id)
-                .text(content.title);
-            $newNode.find(".show-count")
-                .attr("title", "浏览：" + (content.view_count || 0) + "，评论：" + (content.comment_count || 0))
-                .text("(" + (content.view_count || 0) + "," + (content.comment_count || 0) + ")");
-            $newNode.find(".tags")
-                .text(content.tags);
-            $newNode.find(".author")
-                .text(content.author_name);
-            $newNode.find(".createdTimePlaceholder")
-                .text(content.created_time);
-
-            var $meta = $(".meta");
-            var userID = $meta.data("user-id");
-            var role = $meta.data("role");
-            if (userID !== undefined) {
-                if (Number(role) <= 1 || userID === content.author_id) {
-                    $newNode.find(".delete")
-                        .data("user-id", userID)
-                        .data("id", content.id)
-                        .data("author-id", content.author_id)
-                        .removeClass("hide");
-                }
-
-                if (userID === content.author_id) {
-                    $newNode.find(".edit")
-                        .data("user-id", userID)
-                        .data("id", content.id)
-                        .data("author-id", content.author_id)
-                        .removeClass("hide");
-                }
-            }
-
-            if (isLast) {
-                $newNode.removeClass("underline");
-            }
-            $newNode.appendTo($("ul.items"));
-        }
-
-        // change activated page button
-        function activePageBtn(page) {
-            // transform pagination
-            $(".paginator a[data-page='" + PAGE.page + "']").addClass("paging");
-            $(".paging[data-page='" + page + "']").removeClass("paging");
-            PAGE.update(page);
         }
 
         function getSectionID() {
@@ -386,11 +311,6 @@
         $(function () {
                 replaceTime();
                 addListeners();
-
-                // page button click event
-                $(".paginator a").on("click", function () {
-                    loadPage(getSectionID(), $(this).data("page"));
-                });
 
                 // new article
                 $("button.new-article").on("click", function () {

--- a/views/editArticle.html
+++ b/views/editArticle.html
@@ -1,231 +1,233 @@
 {% extends "base.html" %}
 
 {% block title %}
-编辑文章 - Rust语言中文社区
+    编辑文章 - Rust语言中文社区
 {% endblock title %}
 
 {% block content %}
-<style>
-    .body-content {
-        padding: 10px;
-    }
-    .body-content .border {
-        border: gray 1px solid;
-        margin-top: 10px;
-    }
+    <style>
+        .body-content {
+            padding: 10px;
+        }
 
-    .body-content .padding-square {
-        padding: 15px;
-    }
+        .body-content .border {
+            border: gray 1px solid;
+            margin-top: 10px;
+        }
 
-    .body-content .padding-rectangle {
-        padding: 10px 15px;
-    }
+        .body-content .padding-square {
+            padding: 15px;
+        }
 
-    .body-content .padding-samll-rectangle {
-        padding: 5px 10px;
-    }
+        .body-content .padding-rectangle {
+            padding: 10px 15px;
+        }
 
-    .body-content .margin-top {
-        margin-top: 15px;
-    }
+        .body-content .padding-samll-rectangle {
+            padding: 5px 10px;
+        }
 
-    .body-content .margin-bottom {
-        margin-bottom: 15px;
-    }
+        .body-content .margin-top {
+            margin-top: 15px;
+        }
 
-    .body-content .topline {
-        border-top: gray 1px solid;
-    }
+        .body-content .margin-bottom {
+            margin-bottom: 15px;
+        }
 
-    .body-content * {
-        box-sizing: border-box;
-    }
+        .body-content .topline {
+            border-top: gray 1px solid;
+        }
 
-    .body-content a {
-        text-decoration-line: none;
-    }
+        .body-content * {
+            box-sizing: border-box;
+        }
 
-    .body-content a:hover {
-        color: cornflowerblue;
-        cursor: pointer;
-    }
+        .body-content a {
+            text-decoration-line: none;
+        }
 
-    .body-content .input {
-        min-width: 280px;
-        height: 30px;
-        font-size: 18px;
-        width: 60%;
-    }
+        .body-content a:hover {
+            color: cornflowerblue;
+            cursor: pointer;
+        }
 
-    .body-content textarea {
-        width: 100%;
-        min-width: 280px;
-        min-height: 400px;
-        font-size: 15px;
-    }
+        .body-content .input {
+            min-width: 280px;
+            height: 30px;
+            font-size: 18px;
+            width: 60%;
+        }
 
-    .hidden {
-        display: none;
-    }
+        .body-content textarea {
+            width: 100%;
+            min-width: 280px;
+            min-height: 400px;
+            font-size: 15px;
+        }
 
-    #new-article {
-        padding-left: 0;
-    }
-</style>
+        .hidden {
+            display: none;
+        }
 
-<div class="body-content">
-    <h3>
-        <span class="new_article hidden">发表帖子</span>
-        <span class="edit_article hidden">编辑帖子</span>
-    </h3>
-    <div id="new-article" class="padding-rectangle topline">
-        <div>
-            <input class="input" type="text" name="title" placeholder="这里输入标题">
-            <br> <br>
-            <input class="input" type="text" name="tags" placeholder="这里输入标签 以英文逗号分隔">
-            <br> <br>
-            <textarea name="raw-content" placeholder="支持 Markdown 哦，快来试试吧" autofocus></textarea>
-            <br> <br>
-            <button name="submit" data-api="/api/v1/article/new">Biu！发送！</button>
+        #new-article {
+            padding-left: 0;
+        }
+    </style>
+
+    <div class="body-content">
+        <h3>
+            <span class="new_article hidden">发表帖子</span>
+            <span class="edit_article hidden">编辑帖子</span>
+        </h3>
+        <div id="new-article" class="padding-rectangle topline">
+            <div>
+                <input class="input" type="text" name="title" placeholder="这里输入标题">
+                <br> <br>
+                <input class="input" type="text" name="tags" placeholder="这里输入标签 以英文逗号分隔">
+                <br> <br>
+                <textarea name="raw-content" placeholder="支持 Markdown 哦，快来试试吧" autofocus></textarea>
+                <br> <br>
+                <button name="submit" data-api="/api/v1/article/new">Biu！发送！</button>
+            </div>
         </div>
     </div>
-</div>
 
-<script>
-    var queryDict = parseQueryStringToDictionary(window.location.search);
+    <script>
+        var queryDict = parseQueryStringToDictionary(window.location.search);
 
-    // edit article
-    function editArticle(id) {
-        $.getJSON("/api/v1/article/get?id=" + id, function (response) {
-            if (response.status === true) {
-                var data = response.data;
-                $("input[name='title']").val(data.title);
-                $("input[name='tags']").val(data.tags);
-
-                $("div#new-article")
-                    .data("type", "edit")
-                    .data("id", data.id)
-                    .data("author-id", data.author_id)
-                    .show();
-
-                var $textarea = $("textarea[name='raw-content']");
-                $textarea
-                    .val(data.content)
-                    .focus();
-            }
-        });
-    }
-
-    // update article
-    function updateArticle(id, author_id, title, raw_content, tags, success) {
-        $.ajax({
-            type: "POST",
-            url: "/api/v1/article/edit",
-            contentType: 'application/json; charset=utf-8',
-            dataType: "json",
-            data: JSON.stringify({
-                id: id,
-                author_id: author_id,
-                title: title,
-                raw_content: raw_content,
-                tags: tags
-            }),
-            success: function (response) {
+        // edit article
+        function editArticle(id) {
+            $.getJSON("/api/v1/article/get?id=" + id, function (response) {
                 if (response.status === true) {
-                    success();
-                } else {
-                    alert("更新失败");
+                    var data = response.data;
+                    $("input[name='title']").val(data.title);
+                    $("input[name='tags']").val(data.tags);
+
+                    $("div#new-article")
+                        .data("type", "edit")
+                        .data("id", data.id)
+                        .data("author-id", data.author_id)
+                        .show();
+
+                    var $textarea = $("textarea[name='raw-content']");
+                    $textarea
+                        .val(data.content)
+                        .focus();
                 }
-            }
-        });
-    }
-
-    function submit() {
-        var title = $("input[name='title']").val();
-        var tags = $("input[name='tags']").val();
-        var rawContent = $("textarea[name='raw-content']").val();
-        
-        if (title.trim().length === 0 && rawContent.trim().length === 0) {
-            alert("请输入文章标题和内容！");
-            return;
+            });
         }
-        
-        if (title.trim().length === 0) {
-            alert("请输入文章标题！");
-            return;
-        }
-        
-        if (rawContent.trim().length === 0) {
-            alert("请输入文章内容！");
-            return;
-        }
-        
-        $("button[name='submit']").text("正在Biu中...");
-        $("button[name='submit']").on("click", function(){});
-        
-        if ('id' in queryDict) {
-            // update article
-            var id = queryDict.id;
-            var $newArticle = $("div#new-article");
 
-            updateArticle(
-                id,
-                $newArticle.data("author-id"),
-                title,
-                rawContent,
-                tags,
-                function() {
-                    $newArticle.data("type", "new");
-                    alert("更新成功！");
-                    window.location.href = window.location.origin + '/article/' + id;
-                }
-            )
-        } else {
-            // new article
-            var stype = Number(queryDict.stype);
-            var sectionID = queryDict.sectionID;
-
+        // update article
+        function updateArticle(id, author_id, title, raw_content, tags, success) {
             $.ajax({
                 type: "POST",
-                url: $("button[name='submit']").data("api"),
+                url: "/api/v1/article/edit",
                 contentType: 'application/json; charset=utf-8',
                 dataType: "json",
                 data: JSON.stringify({
-                    section_id: sectionID,
-                    stype: stype,
+                    id: id,
+                    author_id: author_id,
                     title: title,
-                    tags: tags,
-                    raw_content: rawContent
+                    raw_content: raw_content,
+                    tags: tags
                 }),
                 success: function (response) {
                     if (response.status === true) {
-                        alert("发表成功！");
-                        window.location.href = "/section/" + sectionID;
+                        success();
                     } else {
-                        alert("发射失败，请检查输入是否完整！");
+                        alert("更新失败");
                     }
                 }
             });
         }
-        $("button[name='submit']").text("Biu！发送！");
-        $("button[name='submit']").on("click", submit);
-    }
 
-    $(function () {
-        // load article from API
-        if ('id' in queryDict) {
-            editArticle(queryDict.id);
+        function submit() {
+            var title = $("input[name='title']").val();
+            var tags = $("input[name='tags']").val();
+            var rawContent = $("textarea[name='raw-content']").val();
 
-            $('.edit_article').show();
+            if (title.trim().length === 0 && rawContent.trim().length === 0) {
+                alert("请输入文章标题和内容！");
+                return;
+            }
+
+            if (title.trim().length === 0) {
+                alert("请输入文章标题！");
+                return;
+            }
+
+            if (rawContent.trim().length === 0) {
+                alert("请输入文章内容！");
+                return;
+            }
+
+            $("button[name='submit']").text("正在Biu中...");
+            $("button[name='submit']").on("click", function () {
+            });
+
+            if ('id' in queryDict) {
+                // update article
+                var id = queryDict.id;
+                var $newArticle = $("div#new-article");
+
+                updateArticle(
+                    id,
+                    $newArticle.data("author-id"),
+                    title,
+                    rawContent,
+                    tags,
+                    function () {
+                        $newArticle.data("type", "new");
+                        alert("更新成功！");
+                        window.location.href = window.location.origin + '/article/' + id;
+                    }
+                )
+            } else {
+                // new article
+                var stype = Number(queryDict.stype);
+                var sectionID = queryDict.sectionID;
+
+                $.ajax({
+                    type: "POST",
+                    url: $("button[name='submit']").data("api"),
+                    contentType: 'application/json; charset=utf-8',
+                    dataType: "json",
+                    data: JSON.stringify({
+                        section_id: sectionID,
+                        stype: stype,
+                        title: title,
+                        tags: tags,
+                        raw_content: rawContent
+                    }),
+                    success: function (response) {
+                        if (response.status === true) {
+                            alert("发表成功！");
+                            window.location.href = "/section/" + sectionID;
+                        } else {
+                            alert("发射失败，请检查输入是否完整！");
+                        }
+                    }
+                });
+            }
+            $("button[name='submit']").text("Biu！发送！");
+            $("button[name='submit']").on("click", submit);
         }
-        else {
-            $('.new_article').show();
-        }
 
-        $("button[name='submit']").on("click", submit);
+        $(function () {
+            // load article from API
+            if ('id' in queryDict) {
+                editArticle(queryDict.id);
 
-        ctrlEnterThen($('textarea'), submit);
-    })
-</script>
+                $('.edit_article').show();
+            }
+            else {
+                $('.new_article').show();
+            }
+
+            $("button[name='submit']").on("click", submit);
+
+            ctrlEnterThen($('textarea'), submit);
+        })
+    </script>
 {% endblock content %}

--- a/views/footer.html
+++ b/views/footer.html
@@ -1,10 +1,10 @@
 <style>
-.footer {
-    border-top: gray 1px solid;
-    line-height: 30px;
-    font-size: 14px;
-    text-align: center;
-}
+    .footer {
+        border-top: gray 1px solid;
+        line-height: 30px;
+        font-size: 14px;
+        text-align: center;
+    }
 </style>
 
 <div class="footer">
@@ -14,16 +14,17 @@
             <a href="https://github.com/rustcc/forustm">Forustm 项目地址</a> &nbsp;&nbsp;&nbsp;
             <span>Rust QQ群：303838735</span>
         </p>
-	<p>©2018 Rust.cc 版权所有 &nbsp;&nbsp; <span class="powered">Powered by <a href="https://github.com/sappworks/sapper">Sapper</a></span></p>
+        <p>©2018 Rust.cc 版权所有 &nbsp;&nbsp; <span class="powered">Powered by <a
+                href="https://github.com/sappworks/sapper">Sapper</a></span></p>
     </div>
 </div>
 
 <script>
     var _hmt = _hmt || [];
-    (function() {
-      var hm = document.createElement("script");
-      hm.src = "https://hm.baidu.com/hm.js?b9a6681a351077586b795305c383771b";
-      var s = document.getElementsByTagName("script")[0]; 
-      s.parentNode.insertBefore(hm, s);
+    (function () {
+        var hm = document.createElement("script");
+        hm.src = "https://hm.baidu.com/hm.js?b9a6681a351077586b795305c383771b";
+        var s = document.getElementsByTagName("script")[0];
+        s.parentNode.insertBefore(hm, s);
     })();
 </script>

--- a/views/header.html
+++ b/views/header.html
@@ -1,71 +1,74 @@
 <style>
-.header {
-    height: 40px;
-    line-height: 40px;
-    border-bottom: gray 1px solid;
-    padding: 0 10px;
-}
-.header .logo img {
-    width: 40px;
-}
+    .header {
+        height: 40px;
+        line-height: 40px;
+        border-bottom: gray 1px solid;
+        padding: 0 10px;
+    }
 
-/* The container <div> - needed to position the dropdown content */
-.userinfo-text {
-    position: relative;
-    display: inline-block;
-    padding: 0 6px;
-}
+    .header .logo img {
+        width: 40px;
+    }
 
-.dropbtn {
-    text-decoration: none;
-    color: #333;
-}
+    /* The container <div> - needed to position the dropdown content */
+    .userinfo-text {
+        position: relative;
+        display: inline-block;
+        padding: 0 6px;
+    }
 
-.dropdown-content {
-    display: none;
-    position: absolute;
-    right: 0;
-    background-color: #f9f9f9;
-    min-width: 160px;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-    z-index: 1;
-}
+    .dropbtn {
+        text-decoration: none;
+        color: #333;
+    }
 
-/* Links inside the dropdown */
-.dropdown-content a {
-    color: #333;
-    padding: 6px 16px;
-    text-decoration: none;
-    display: block;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-}
+    .dropdown-content {
+        display: none;
+        position: absolute;
+        right: 0;
+        background-color: #f9f9f9;
+        min-width: 160px;
+        box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+        z-index: 1;
+    }
 
-/* Change color of dropdown links on hover */
-.dropdown-content a:hover {background-color: #fff;}
+    /* Links inside the dropdown */
+    .dropdown-content a {
+        color: #333;
+        padding: 6px 16px;
+        text-decoration: none;
+        display: block;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+    }
 
-/* Show the dropdown menu on hover */
-.userinfo-text:hover .dropdown-content {
-    display: block;
-}
+    /* Change color of dropdown links on hover */
+    .dropdown-content a:hover {
+        background-color: #fff;
+    }
 
-.user-notifys {
-    float: left;
-    font-size: 14px;
-    position: relative;
-    display: inline-block;
-    padding: 0 6px;
-    line-height: 42px;
-}
+    /* Show the dropdown menu on hover */
+    .userinfo-text:hover .dropdown-content {
+        display: block;
+    }
 
-.user-notifys .dropdown-content {
-    max-width: 315px;
-}
+    .user-notifys {
+        float: left;
+        font-size: 14px;
+        position: relative;
+        display: inline-block;
+        padding: 0 6px;
+        line-height: 42px;
+    }
 
-.user-notifys:hover .dropdown-content {
-    display: block;
-}
+    .user-notifys .dropdown-content {
+        max-width: 315px;
+    }
+
+    .user-notifys:hover .dropdown-content {
+        display: block;
+    }
 
 </style>
 
@@ -79,36 +82,36 @@
     </div>
 
     <div class="userinfo right">
-      {% if user %}
-        {% if user_notifys | length != 0 %}
-        <div class="user-notifys">
-            <a href="#">消息({{ user_notifys | length }})</a>
-            <div class="dropdown-content">
-                {% for notify in user_notifys %}
-                <a href="/article/{{ notify.article_id }}"
-                    target="_blank"
-                    title="{{ notify.send_user_name }} {% if notify.notify_type == "reply" %} 回复 {% elif notify.notify_type == "comment" %} 评论 {%else %} 搞事情！{% endif %} 了你，帖子: {{ notify.article_title }}">
-                    {{ notify.send_user_name }}
-                    {% if notify.notify_type == "reply" %} 回复
-                    {% elif notify.notify_type == "comment" %} 评论
-                    {% else %} 搞事情！{% endif %}
-                    了你，帖子: {{ notify.article_title }}
-                </a>
-                {% endfor %}
+        {% if user %}
+            {% if user_notifys | length != 0 %}
+                <div class="user-notifys">
+                    <a href="#">消息({{ user_notifys | length }})</a>
+                    <div class="dropdown-content">
+                        {% for notify in user_notifys %}
+                            <a href="/article/{{ notify.article_id }}"
+                               target="_blank"
+                               title="{{ notify.send_user_name }} {% if notify.notify_type == "reply" %} 回复 {% elif notify.notify_type == "comment" %} 评论 {% else %} 搞事情！{% endif %} 了你，帖子: {{ notify.article_title }}">
+                                {{ notify.send_user_name }}
+                                {% if notify.notify_type == "reply" %} 回复
+                                {% elif notify.notify_type == "comment" %} 评论
+                                {% else %} 搞事情！{% endif %}
+                                了你，帖子: {{ notify.article_title }}
+                            </a>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
+            <div class="userinfo-text">
+                <a class="dropbtn" href="#">{{ user.nickname }}</a>
+                <div class="dropdown-content">
+                    <a href="/home">个人主页</a>
+                    <a href="/blog/{{ user.id }}">我的博客</a>
+                    {% if user_blog_section %}
+                        <a href="/user/article/edit?sectionID={{ user_blog_section.id }}&stype=1">写博客</a>
+                    {% endif %}
+                    <a id="sign_out" href="/api/v1/user/sign_out">退出</a>
+                </div>
             </div>
-        </div>
-        {% endif %}
-        <div class="userinfo-text">
-            <a class="dropbtn" href="#">{{ user.nickname }}</a>
-            <div class="dropdown-content">
-                <a href="/home">个人主页</a>
-                <a href="/blog/{{ user.id }}">我的博客</a>
-                {% if user_blog_section %}
-                <a href="/user/article/edit?sectionID={{user_blog_section.id}}&stype=1">写博客</a>
-                {% endif %}
-                <a id="sign_out" href="/api/v1/user/sign_out">退出</a>
-            </div>
-        </div>
         {% else %}
             <span class="userinfo-text"><a href="/login">登录</a></span>
         {% endif %}
@@ -116,21 +119,21 @@
     <div style="clear:both;"></div>
 </div>
 <script type="application/javascript">
-$('#sign_out').click(function(event) {
-    event.preventDefault();
+    $('#sign_out').click(function (event) {
+        event.preventDefault();
 
-    $.ajax({
-        url: $(this).attr('href'),
-        type: "get",
-        success: function (res) {
-            if (res.status) {
-                console.log(res.status);
-                window.location = "/"
-            } else {
-                console.log("sign_out error");
+        $.ajax({
+            url: $(this).attr('href'),
+            type: "get",
+            success: function (res) {
+                if (res.status) {
+                    console.log(res.status);
+                    window.location = "/"
+                } else {
+                    console.log("sign_out error");
+                }
             }
-        }
-    })
-    return false; // for good measure
-});
+        })
+        return false; // for good measure
+    });
 </script>

--- a/views/home.html
+++ b/views/home.html
@@ -1,81 +1,86 @@
 {% extends "base.html" %}
 
 {% block title %}
-{{ user.nickname }} - Rust语言中文社区
+    {{ user.nickname }} - Rust语言中文社区
 {% endblock title %}
 
 {% block script %}
-<script src="/js/home.js"></script>
-<link href="/css/home.css" rel="stylesheet" />
+    <script src="/js/home.js"></script>
+    <link href="/css/home.css" rel="stylesheet"/>
 {% endblock script %}
 
 {% block content %}
-<nav class="navigation">
-    <ul>
-        <li><a id="information_btn" class="active">个人信息</a></li>
-        <li><a id="modify_btn">修改信息</a></li>
-        <li><a id="change_password_btn">修改密码</a></li>
-        <li><a href="/blog/{{ user.id }}">博客</a></li>
-    </ul>
-</nav>
-<div class="information module">
-    <h3>用户信息</h3>
-    {% if user.avatar %}
-    <img class="avatar" src="{{ user.avatar }}" id="path">
-    <img class="avatar round-avatar" src="{{ user.avatar }}">
-    {% else %}
-    <!--
-    <img class="avatar anonymous" src="">
-    <img class="avatar round-avatar anonymous" src=""> -->
-    {% endif %}
-    <hr/>
-    <div><label>账号：</label><p style="display:inline;">{{ user.account }}<p></div>
-    <div><label>昵称：</label><p style="display:inline;" class="nickname">{{ user.nickname }}<p></div>
-    <div><label>Github：</label><p style="display:inline;" class="github">{{ user.github }}<p></div>
-    <div><label>微信号：</label><p style="display:inline;" class="wx_openid">{{ user.wx_openid }}<p></div>
-    <div><label>签名：</label>
-        <p style="display:inline;" class="say">{{ user.say }}</p>
+    <nav class="navigation">
+        <ul>
+            <li><a id="information_btn" class="active">个人信息</a></li>
+            <li><a id="modify_btn">修改信息</a></li>
+            <li><a id="change_password_btn">修改密码</a></li>
+            <li><a href="/blog/{{ user.id }}">博客</a></li>
+        </ul>
+    </nav>
+    <div class="information module">
+        <h3>用户信息</h3>
+        {% if user.avatar %}
+            <img class="avatar" src="{{ user.avatar }}" id="path">
+            <img class="avatar round-avatar" src="{{ user.avatar }}">
+        {% else %}
+            <!--
+            <img class="avatar anonymous" src="">
+            <img class="avatar round-avatar anonymous" src=""> -->
+        {% endif %}
+        <hr/>
+        <div><label>账号：</label>
+            <p style="display:inline;">{{ user.account }}<p></div>
+        <div><label>昵称：</label>
+            <p style="display:inline;" class="nickname">{{ user.nickname }}<p></div>
+        <div><label>Github：</label>
+            <p style="display:inline;" class="github">{{ user.github }}<p></div>
+        <div><label>微信号：</label>
+            <p style="display:inline;" class="wx_openid">{{ user.wx_openid }}<p></div>
+        <div><label>签名：</label>
+            <p style="display:inline;" class="say">{{ user.say }}</p>
+        </div>
+        <div><label>创建时间：</label>
+            <p style="display:inline;" class="signup_time">{{ user.signup_time }}</p></div>
+        <br/>
     </div>
-    <div><label>创建时间：</label><p style="display:inline;" class="signup_time">{{ user.signup_time }}</p></div>
-    <br />
-</div>
-<div class="modify module">
-    <h3>修改信息</h3>
-    <hr/>
-    <form>
-        <div class="form-group">
-            <label>昵称:</label><input id="nickname" type="text" class="form-control">
-        </div>
-        <div class="form-group">
-            <label>签名:</label><textarea id="say" rows="5"></textarea>
-        </div>
-        <div class="form-group">
-            <label>头像地址:</label><input id="avatar" type="text">
-        </div>
-        <div class="form-group">
-            <label>微信号:</label><input id="wx_openid" type="text">
-        </div>
-        <div class="form-group">
-            <button type="button" class="btn btn-success pull-right">保存</button>
-        </div>
-    </form>
-</div>
-<div class="change_password module">
-    <h3>修改密码</h3>
-    <hr/>
-    <form>
-        <div class="form-group">
-            <label>旧密码:</label><input id="old_password" type="password" maxlength="20">
-        </div>
-        <div class="form-group">
-            <label>新密码:</label><input id="new_password" type="password" maxlength="20">
-        </div>
-        <div class="form-group">
-            <label>再次输入:</label><input id="re_password" type="password" maxlength="20">
-        </div>
-        <div class="form-group">
-            <button type="button" class="btn btn-success pull-right">提交</button>
-        </div>
-    </form>
-</div>
+    <div class="modify module">
+        <h3>修改信息</h3>
+        <hr/>
+        <form>
+            <div class="form-group">
+                <label>昵称:</label><input id="nickname" type="text" class="form-control">
+            </div>
+            <div class="form-group">
+                <label>签名:</label><textarea id="say" rows="5"></textarea>
+            </div>
+            <div class="form-group">
+                <label>头像地址:</label><input id="avatar" type="text">
+            </div>
+            <div class="form-group">
+                <label>微信号:</label><input id="wx_openid" type="text">
+            </div>
+            <div class="form-group">
+                <button type="button" class="btn btn-success pull-right">保存</button>
+            </div>
+        </form>
+    </div>
+    <div class="change_password module">
+        <h3>修改密码</h3>
+        <hr/>
+        <form>
+            <div class="form-group">
+                <label>旧密码:</label><input id="old_password" type="password" maxlength="20">
+            </div>
+            <div class="form-group">
+                <label>新密码:</label><input id="new_password" type="password" maxlength="20">
+            </div>
+            <div class="form-group">
+                <label>再次输入:</label><input id="re_password" type="password" maxlength="20">
+            </div>
+            <div class="form-group">
+                <button type="button" class="btn btn-success pull-right">提交</button>
+            </div>
+        </form>
+    </div>
 {% endblock content %}

--- a/views/index.html
+++ b/views/index.html
@@ -124,7 +124,8 @@
                     <ul>
                         {% for blog in blogs %}
                             <li>
-                                <a href="/article/{{ blog.id }}">{{ blog.author_name }}：{{ blog.title }}</a>
+                                <a data-node-type="child"
+                                   href="/article/{{ blog.id }}">{{ blog.author_name }}：{{ blog.title }}</a>
                                 <!--
                     <span class="right">
                         <span class="tags">{{ blog.tags }}</span>
@@ -151,7 +152,7 @@
                             <ul>
                                 {% for s in section.2 %}
                                     <li>
-                                        <a href="/article/{{ s.id }}">{{ s.title }}</a>
+                                        <a data-node-type="child" href="/article/{{ s.id }}">{{ s.title }}</a>
                                     </li>
                                 {% endfor %}
                             </ul>

--- a/views/index.html
+++ b/views/index.html
@@ -1,194 +1,194 @@
 {% extends "base.html" %}
 
 {% block title %}
-Rust语言中文社区-首页
+    Rust语言中文社区-首页
 {% endblock title %}
 
 {% block content %}
-<style>
-.body-content {
-    padding: 10px;
-}
+    <style>
+        .body-content {
+            padding: 10px;
+        }
 
-.desc {
-    font-size: 14px;
-    margin-top: 8px;
-}
+        .desc {
+            font-size: 14px;
+            margin-top: 8px;
+        }
 
-.head {
-    border-bottom: gray 1px solid;
-    height: 24px;
-    line-height: 24px;
-}
+        .head {
+            border-bottom: gray 1px solid;
+            height: 24px;
+            line-height: 24px;
+        }
 
-.head a {
-    text-decoration: none;
-    color: #222;
-}
+        .head a {
+            text-decoration: none;
+            color: #222;
+        }
 
-.container {
-    padding: 8px 0;
-}
+        .container {
+            padding: 8px 0;
+        }
 
-.container a {
-    text-decoration: underline;
-    color: blue;
-}
+        .container a {
+            text-decoration: underline;
+            color: blue;
+        }
 
-.container a:visited {
-    color: blueviolet;
-}
+        .container a:visited {
+            color: blueviolet;
+        }
 
-.planet-space .container {
-    padding: 8px;
-}
+        .planet-space .container {
+            padding: 8px;
+        }
 
-ul li {
-    list-style-type: none;
-    height: 24px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-}
+        ul li {
+            list-style-type: none;
+            height: 24px;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+        }
 
-.body-content .notice {
-    /* border: gray 1px solid; */
-    padding: 4px;
-    min-height: 50px;
-    text-align: center;
-    margin-top: 5px;
-}
+        .body-content .notice {
+            /* border: gray 1px solid; */
+            padding: 4px;
+            min-height: 50px;
+            text-align: center;
+            margin-top: 5px;
+        }
 
-.body-content .planet-space {
-    border: gray 1px solid;
-    padding-bottom: 4px;
-    height: 108px;
-    text-align: center;
-    margin-top: 15px;
-}
+        .body-content .planet-space {
+            border: gray 1px solid;
+            padding-bottom: 4px;
+            height: 108px;
+            text-align: center;
+            margin-top: 15px;
+        }
 
-.body-content .category-section {
-    margin-top: 15px;
-    margin-right: -15px;
-}
+        .body-content .category-section {
+            margin-top: 15px;
+            margin-right: -15px;
+        }
 
-.one-section {
-    width: calc(31% - 15px);
-    margin-right: 15px;
-    margin-bottom: 15px;
-    padding: 10px;
-    border: gray 1px solid;
-    height: 104px;
-    float: left;
-    min-width: 276px;
-}
+        .one-section {
+            width: calc(31% - 15px);
+            margin-right: 15px;
+            margin-bottom: 15px;
+            padding: 10px;
+            border: gray 1px solid;
+            height: 104px;
+            float: left;
+            min-width: 276px;
+        }
 
-@media screen and (max-width: 960px) {
-    .one-section {
-        width: calc(100% - 50px);
-    }
-}
+        @media screen and (max-width: 960px) {
+            .one-section {
+                width: calc(100% - 50px);
+            }
+        }
 
-.body-content .incubation-area .incubation-area-container {
-    margin-top: 15px;
-    margin-right: -15px;
-}
+        .body-content .incubation-area .incubation-area-container {
+            margin-top: 15px;
+            margin-right: -15px;
+        }
 
-.body-content .incubation-area .incubation-area-head {
-    height: 24px;
-    line-height: 24px;
-    border: gray 1px solid;
-    text-align: center;
-}
-</style>
+        .body-content .incubation-area .incubation-area-head {
+            height: 24px;
+            line-height: 24px;
+            border: gray 1px solid;
+            text-align: center;
+        }
+    </style>
 
 
 
-<div class="body-content">
-    
-    <div class="notice">
-      {% if title and desc %}
-        <p class="title">{{ title }}</p>
-        <p class="desc">{{ desc }}</p>
-      {% endif %}
-    </div>
+    <div class="body-content">
 
-    <div class="planet-space">
-        <div class="planet-space-head head">
-            <a href="/blogs">Rust 博客星球</a>
+        <div class="notice">
+            {% if title and desc %}
+                <p class="title">{{ title }}</p>
+                <p class="desc">{{ desc }}</p>
+            {% endif %}
         </div>
-        <div class="planet-space-container container">
-        {% if blogs | length == 0 %}
-            <p>这里还没有内容哦……</p>
-        {% else %}
-            <ul>
-            {% for blog in blogs %} 
-                <li>
-			<a href="/article/{{ blog.id }}">{{ blog.author_name }}：{{ blog.title }}</a>
-                    <!--
+
+        <div class="planet-space">
+            <div class="planet-space-head head">
+                <a href="/blogs">Rust 博客星球</a>
+            </div>
+            <div class="planet-space-container container">
+                {% if blogs | length == 0 %}
+                    <p>这里还没有内容哦……</p>
+                {% else %}
+                    <ul>
+                        {% for blog in blogs %}
+                            <li>
+                                <a href="/article/{{ blog.id }}">{{ blog.author_name }}：{{ blog.title }}</a>
+                                <!--
                     <span class="right">
                         <span class="tags">{{ blog.tags }}</span>
                         <span class="createdTime">{{ blog.created_time }}</span>
                     </span>
                     -->
-                </li>
-            {% endfor %}
-            </ul>
-        {% endif %}
-        </div>
-    </div>
-
-    <div class="category-section">
-    {% if cate_sections_len  == 0 %}
-        <p>这里还没有内容哦……</p>
-    {% else %}
-        {% for key, section in sections_hash %}
-        <div class="one-section">
-            <div class="one-section-head head">
-                <a href="/section/{{ section.0 }}">{{ section.1 }}</a>
-            </div>
-            <div class="one-section-container container">
-                <ul>
-                    {% for s in section.2 %}
-                    <li>
-                        <a href="/article/{{ s.id }}">{{ s.title }}</a>
-                    </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        </div>
-        {% endfor %}
-    {% endif %}
-        <div style="clear:both;"></div>
-    </div>
-
-    <div class="incubation-area">
-        <div class="incubation-area-head">
-            <p>Rust 项目专题</p>
-        </div>
-        {% if proj_sections_len == 0 %}
-        <p>这里还没有内容哦……</p>
-        {% else %}
-        <div class="incubation-area-container">
-            {% for key, section in projects_hash %}
-            <div class="one-section">
-                <div class="one-section-head head">
-                    <a href="/section/{{ section.0 }}">{{ section.1 }}</a>
-                </div>
-                <div class="one-section-container container">
-                    <ul>
-                        {% for s in section.2 %}
-                        <li>
-                            <a href="/article/{{ s.id }}">{{ s.title }}</a>
-                        </li>
+                            </li>
                         {% endfor %}
                     </ul>
-                </div>
+                {% endif %}
             </div>
-            {% endfor %}
-        {% endif %}
+        </div>
+
+        <div class="category-section">
+            {% if cate_sections_len  == 0 %}
+                <p>这里还没有内容哦……</p>
+            {% else %}
+                {% for key, section in sections_hash %}
+                    <div class="one-section">
+                        <div class="one-section-head head">
+                            <a href="/section/{{ section.0 }}">{{ section.1 }}</a>
+                        </div>
+                        <div class="one-section-container container">
+                            <ul>
+                                {% for s in section.2 %}
+                                    <li>
+                                        <a href="/article/{{ s.id }}">{{ s.title }}</a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    </div>
+                {% endfor %}
+            {% endif %}
             <div style="clear:both;"></div>
         </div>
+
+        <div class="incubation-area">
+            <div class="incubation-area-head">
+                <p>Rust 项目专题</p>
+            </div>
+            {% if proj_sections_len == 0 %}
+                <p>这里还没有内容哦……</p>
+            {% else %}
+                <div class="incubation-area-container">
+                {% for key, section in projects_hash %}
+                    <div class="one-section">
+                        <div class="one-section-head head">
+                            <a href="/section/{{ section.0 }}">{{ section.1 }}</a>
+                        </div>
+                        <div class="one-section-container container">
+                            <ul>
+                                {% for s in section.2 %}
+                                    <li>
+                                        <a href="/article/{{ s.id }}">{{ s.title }}</a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    </div>
+                {% endfor %}
+            {% endif %}
+            <div style="clear:both;"></div>
+            </div>
+        </div>
     </div>
-</div>
 {% endblock content %}

--- a/views/login.html
+++ b/views/login.html
@@ -1,146 +1,153 @@
 {% extends "base.html" %}
 
 {% block title %}
-登录 - Rust语言中文社区
+    登录 - Rust语言中文社区
 {% endblock title %}
 
 {% block script %}
-<script src="/js/login.js"></script>
+    <script src="/js/login.js"></script>
 {% endblock script %}
 
 {% block content %}
-<style>
-    .content-area {
-        padding: 15px;
-    }
+    <style>
+        .content-area {
+            padding: 15px;
+        }
 
-    #login_form {
-        display: block;
-    }
+        #login_form {
+            display: block;
+        }
 
-    #register_form {
-        display: none;
-    }
+        #register_form {
+            display: none;
+        }
 
-    #reset_form {
-        display: none;
-    }
+        #reset_form {
+            display: none;
+        }
 
-    a:hover {
-        text-decoration: none;
-        cursor: pointer;
-    }
+        a:hover {
+            text-decoration: none;
+            cursor: pointer;
+        }
 
-    a {
-        color: -webkit-link;
-        text-decoration: underline;
-        cursor: auto;
-    }
+        a {
+            color: -webkit-link;
+            text-decoration: underline;
+            cursor: auto;
+        }
 
-    .text-danger {
-        color: red
-    }
+        .text-danger {
+            color: red
+        }
 
-    .remember {
-        display: block;
-        padding: 8px 0;
-    }
+        .remember {
+            display: block;
+            padding: 8px 0;
+        }
 
-    .strongit {
-        font-size: 15px;
-    }
+        .strongit {
+            font-size: 15px;
+        }
 
-    .icon {
-      display:inline-block;
-    }
-</style>
+        .icon {
+            display: inline-block;
+        }
+    </style>
 
-<div class="content-area">
-<div id="login_form">
-    <b>Login</b>
-    <br>
-    <br>
-    <form>
-        <table border="0">
-            <tbody>
-            <tr>
-                <td>Account:</td>
-                <td><input type="text" name="account" value="" size="20" autofocus="autofocus" placeholder="Email" id="login_account"></td>
-            </tr>
-            <tr>
-                <td>Password:</td>
-                <td><input type="password" name="password" value="" size="20" placeholder="Password" id="login_password"></td>
-            </tr>
-            </tbody>
-        </table>
-        <label class="checkbox remember">
-            <input type="checkbox" name="remember" class=""/> Remember 90 day
-        </label>
-        <input type="button" class="btn btn-success pull-right" id="login" value="Login "/>
-    </form>
-    <br>
-    <a id="forget">Forgot your password?</a><br/>
-    <a id="register_btn" class="">Create an account</a><hr />
-    <h4>其他登录方式</h4>
-    <a class="icon" href="https://github.com/login/oauth/authorize?scope=user:email&client_id=3160b870124b1fcfc4cb">
-        <svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1" viewBox="0 0 16 16"
-             width="32">
-            <path fill-rule="evenodd"
-                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z">
-            </path>
-        </svg>
-    </a>
-    <br>
-    <br>
-</div>
-<div id="register_form">
-    <b>Create Account</b>
-    <br>
-    <br>
-    <form>
-        <table border="0">
-            <tbody>
-            <tr>
-                <td>Account:</td>
-                <td><input type="text" name="acct" value="" size="20" placeholder="Email" id="register_account"></td>
-                <td class="strongit"><strong>Please fill in the real and valid email address</strong></td>
-            </tr>
-            <tr>
-                <td>Password:</td>
-                <td><input type="password" name="pw" value="" size="20" id="register_password"></td>
-            </tr>
-            <tr>
-                <td>Nickname:</td>
-                <td><input type="text" id="nickname" class="required"></td>
-            </tr>
-            </tbody>
-        </table>
-        <br>
-        <input type="button" id="sign_up" value="Sign up "/>
-        <input type="button" class="back_btn" value="Back"/>
-    </form>
-    <br>
-    <br>
-</div>
-<div id="reset_form">
-    <b>Reset your password</b>
-    <br>
-    <br>
-    <form>
-        <table border="0">
-            <tbody>
-            <tr>
-                <td>Account:</td>
-                <td><input type="text" name="acct" value="" size="20" placeholder="Email" id="reset_account"></td>
-            </tr>
-            </tbody>
-        </table>
-        <br>
-        <input type="button" id="reset_btn" value="Reset"/>
-        <input type="button" class="back_btn" value="Back"/>
-    </form>
-    <br>
-    <br>
-</div>
-</div>
+    <div class="content-area">
+        <div id="login_form">
+            <b>Login</b>
+            <br>
+            <br>
+            <form>
+                <table border="0">
+                    <tbody>
+                    <tr>
+                        <td>Account:</td>
+                        <td><input type="text" name="account" value="" size="20" autofocus="autofocus"
+                                   placeholder="Email" id="login_account"></td>
+                    </tr>
+                    <tr>
+                        <td>Password:</td>
+                        <td><input type="password" name="password" value="" size="20" placeholder="Password"
+                                   id="login_password"></td>
+                    </tr>
+                    </tbody>
+                </table>
+                <label class="checkbox remember">
+                    <input type="checkbox" name="remember" class=""/> Remember 90 day
+                </label>
+                <input type="button" class="btn btn-success pull-right" id="login" value="Login "/>
+            </form>
+            <br>
+            <a id="forget">Forgot your password?</a><br/>
+            <a id="register_btn" class="">Create an account</a>
+            <hr/>
+            <h4>其他登录方式</h4>
+            <a class="icon"
+               href="https://github.com/login/oauth/authorize?scope=user:email&client_id=3160b870124b1fcfc4cb">
+                <svg aria-hidden="true" class="octicon octicon-mark-github" height="32" version="1.1"
+                     viewBox="0 0 16 16"
+                     width="32">
+                    <path fill-rule="evenodd"
+                          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z">
+                    </path>
+                </svg>
+            </a>
+            <br>
+            <br>
+        </div>
+        <div id="register_form">
+            <b>Create Account</b>
+            <br>
+            <br>
+            <form>
+                <table border="0">
+                    <tbody>
+                    <tr>
+                        <td>Account:</td>
+                        <td><input type="text" name="acct" value="" size="20" placeholder="Email" id="register_account">
+                        </td>
+                        <td class="strongit"><strong>Please fill in the real and valid email address</strong></td>
+                    </tr>
+                    <tr>
+                        <td>Password:</td>
+                        <td><input type="password" name="pw" value="" size="20" id="register_password"></td>
+                    </tr>
+                    <tr>
+                        <td>Nickname:</td>
+                        <td><input type="text" id="nickname" class="required"></td>
+                    </tr>
+                    </tbody>
+                </table>
+                <br>
+                <input type="button" id="sign_up" value="Sign up "/>
+                <input type="button" class="back_btn" value="Back"/>
+            </form>
+            <br>
+            <br>
+        </div>
+        <div id="reset_form">
+            <b>Reset your password</b>
+            <br>
+            <br>
+            <form>
+                <table border="0">
+                    <tbody>
+                    <tr>
+                        <td>Account:</td>
+                        <td><input type="text" name="acct" value="" size="20" placeholder="Email" id="reset_account">
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                <br>
+                <input type="button" id="reset_btn" value="Reset"/>
+                <input type="button" class="back_btn" value="Back"/>
+            </form>
+            <br>
+            <br>
+        </div>
+    </div>
 {% endblock content %}

--- a/views/reset_password.html
+++ b/views/reset_password.html
@@ -1,28 +1,28 @@
 {% extends "base.html" %}
 
 {% block title %}
-重置密码 - Rust语言中文社区
+    重置密码 - Rust语言中文社区
 {% endblock title %}
 
 {% block script %}
-<script src="/js/reset_pwd.js"></script>
-<link href="/css/reset_pwd.css" rel="stylesheet" />
+    <script src="/js/reset_pwd.js"></script>
+    <link href="/css/reset_pwd.css" rel="stylesheet"/>
 {% endblock script %}
 
 {% block content %}
-<div class="change_password module">
-    <h3>重置密码</h3>
-    <hr/>
-    <form>
-        <div class="form-group">
-            <label>新密码:</label><input id="new_password" type="password" maxlength="20">
-        </div>
-        <div class="form-group">
-            <label>再次输入:</label><input id="re_password" type="password" maxlength="20">
-        </div>
-        <div class="form-group">
-            <button type="button" class="btn btn-success pull-right">提交</button>
-        </div>
-    </form>
-</div>
+    <div class="change_password module">
+        <h3>重置密码</h3>
+        <hr/>
+        <form>
+            <div class="form-group">
+                <label>新密码:</label><input id="new_password" type="password" maxlength="20">
+            </div>
+            <div class="form-group">
+                <label>再次输入:</label><input id="re_password" type="password" maxlength="20">
+            </div>
+            <div class="form-group">
+                <button type="button" class="btn btn-success pull-right">提交</button>
+            </div>
+        </form>
+    </div>
 {% endblock content %}


### PR DESCRIPTION
**主要目标： 论坛几乎完全修改为服务端渲染，加强SEO效果。**

# TODO LIST:

## BUG修复

+ [x] "确认删除前发出删除请求"的问题。

## 新增特性

+ [x] 根据URL参数跳转至对应回贴页面。
+ [x] 回贴页面跳转由JS部分刷新改为全页面跳转(使用`a`标签)。
+ [x] 根据URL参数跳转至对应博客星球总目录页面。
+ [x] 博客星球总目录页面跳转由JS部分刷新改为全页面跳转(使用`a`标签)。
+ [x] 根据URL参数跳转至对应个人博客目录页面。
+ [x] 个人博客目录页面跳转由JS部分刷新改为全页面跳转(使用`a`标签)。
+ [x] "返回板块"、"返回博客"由总跳转至对应目录第一页改为跳转至进入该页面前所在页面。 #75 

# TIPS

+ 仅考虑Chrome、FireFox、Edge最新版本兼容性(三者均强制自动更新)。
+ 尽可能使用现代JS语法，减少jQuery的使用。(新加入部分JS均使用ES6语法，暂为修改旧有部分)
+ 尽可能避免使用较为重型的前端构建工具，减少后期维护成本(毕竟这边没几个人写前端的)。
+ 可能会逐步使用[Sapper_ntd](https://github.com/DCjanus/sapper_ntd)代替[Sapper_std](https://github.com/sappworks/sapper_std)，即使用一般函数代替宏，节约电力(大雾)，~实现DCjanus的邪恶目标~，IDE friendly(对，就是这个目的)。